### PR TITLE
Fix occasionally failing start_date specs

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -18,7 +18,7 @@ class Partner < ActiveRecord::Base
 
   def set_defaults
     self.status ||= Status.find_by_name("Under Revision")
-    self.partnership_start_date ||= Date.today
+    self.partnership_start_date ||= Date.current
   end
 
   def generate_osra_num

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -18,7 +18,7 @@ class Sponsor < ActiveRecord::Base
 
   def set_defaults
     self.status ||= Status.find_by_name('Under Revision')
-    self.sponsorship_start_date ||= Date.today
+    self.sponsorship_start_date ||= Date.current
   end
 
   def generate_osra_num

--- a/lib/date_validator.rb
+++ b/lib/date_validator.rb
@@ -3,9 +3,9 @@ module DateValidator
 
   def validate_date_not_in_future
     if self.is_a?(Partner)
-      self.errors.add(:partnership_start_date, "is not valid (should not be in the future)") unless (self.partnership_start_date||Date.today) <= Date.today
+      self.errors.add(:partnership_start_date, "is not valid (should not be in the future)") unless (self.partnership_start_date||Date.current) <= Date.current
     elsif self.is_a?(Sponsor)
-    	self.errors.add(:sponsorship_start_date, "is not valid (should not be in the future)") unless (self.sponsorship_start_date||Date.today) <= Date.today
+    	self.errors.add(:sponsorship_start_date, "is not valid (should not be in the future)") unless (self.sponsorship_start_date||Date.current) <= Date.current
   	end
   end
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -33,7 +33,7 @@ describe Partner do
 
   it 'partnership start date should default to today date' do
     partner = Partner.create(:name => 'Partner One',:province => @province1 )
-    expect(partner.partnership_start_date).to eq Date.today
+    expect(partner.partnership_start_date).to eq Date.current
   end
 
   it 'partnership start date should be set to a custom date when specified' do

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -37,7 +37,7 @@ describe Sponsor do
 
   it 'sponsorship start date should default to today date' do
     sponsor = Sponsor.create(name: 'sponsor1', country: 'syria', sponsor_type: @type, gender: 'Male')
-    expect(sponsor.sponsorship_start_date).to eq Date.today
+    expect(sponsor.sponsorship_start_date).to eq Date.current
   end
 
   it 'sponsorship start date should be set to a custom date when specified' do


### PR DESCRIPTION
Pivotal Bug https://www.pivotaltracker.com/story/show/77245130.

Converted all uses of `Date.today` to `Date.current`. See [here](http://nikitaavvakumov.github.io/posts/date-in-ruby-vs-rails/) for explanation.
