### PR TITLE
Cucumber fix for Nested Features

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip -r features/"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features


### PR DESCRIPTION
Added `-r features/` to the list of default opts for cucumber so that features with more than one level of nesting under the features directory can be run without problems.
