### PR TITLE
Fix occasionally failing date_validator specs

### DIFF
--- a/spec/validators/date_not_in_future_validator_spec.rb
+++ b/spec/validators/date_not_in_future_validator_spec.rb
@@ -14,7 +14,7 @@ describe DateNotInFutureValidator do
   subject { test_model.new }
 
   it 'passes when attribute is a valid date' do
-    subject.date_attr = Date.today
+    subject.date_attr = Date.current
     expect(subject).to be_valid
   end
 


### PR DESCRIPTION
Replace Date.today with Date.current in date_not_in_future_validator_spec to prevent spec from failing when local system date is different from app date (UTC). Feels familiar :smile: 
