### PR TITLE
Disable province selector on partner edit page

### DIFF
--- a/app/admin/partner.rb
+++ b/app/admin/partner.rb
@@ -34,7 +34,11 @@ ActiveAdmin.register Partner do
         f.input :osra_num, :input_html => { :readonly => true }
       end
       f.input :name
-      f.input :province
+      if f.object.new_record?
+        f.input :province
+      else
+        f.input :province, :input_html => { :disabled => true }
+      end
       f.input :region
       f.input :contact_details
       f.input :start_date, as: :datepicker

--- a/features/admin/partners.feature
+++ b/features/admin/partners.feature
@@ -75,6 +75,11 @@ Feature:
     And I should see "Partner was successfully updated"
     And I should see "New Region"
 
+  Scenario: Should not be able to edit a partner's province or osra_num
+    Given I am on the "Edit Partner" page for partner "Partner1"
+    Then I should not be able to change "Province"
+    And I should not be able to change "OSRA num"
+
   Scenario: Should not be able to delete a partner from the partner show page
     Given I am on the "Show Partner" page for partner "Partner1"
     Then I should not see the "Delete Partner" link

--- a/features/step_definitions/admin/partners_steps.rb
+++ b/features/step_definitions/admin/partners_steps.rb
@@ -37,4 +37,10 @@ Then(/^I should see the following codes for partners:$/) do |table|
   end
 end
 
+Then(/^I should not be able to change "Province"$/) do
+  expect(find('#partner_province_id')['disabled']).to eq 'disabled'
+  end
 
+Then(/^I should not be able to change "OSRA num"$/) do
+  expect(find('#partner_osra_num')['readonly']).to eq 'readonly'
+end


### PR DESCRIPTION
PT story https://www.pivotaltracker.com/story/show/79119752
- disable province selector in partner edit view
- create scenario to test that partner province & osra_num cannot be changed for persisted records
