### PR TITLE
Update coffee-rails gem to ~> 4.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 4.1.6'
 
 gem 'pg'
 gem 'sass-rails', '~> 4.0.0'
-gem 'coffee-rails', '~> 4.0.0'
+gem 'coffee-rails', '~> 4.1.0'
 gem 'uglifier', '>= 1.3.0' # compressor for JavaScript assets
 gem 'activeadmin', github: 'activeadmin'
 gem 'sequenced' # Sequential IDs in Models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     cocaine (0.5.4)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
-    coffee-rails (4.0.1)
+    coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
     coffee-script (2.3.0)
@@ -311,7 +311,7 @@ DEPENDENCIES
   binding_of_caller
   capybara
   capybara-webkit
-  coffee-rails (~> 4.0.0)
+  coffee-rails (~> 4.1.0)
   country_select!
   coveralls
   cucumber-rails


### PR DESCRIPTION
No JIRA task
- update coffee-rails gem to ~> 4.1.0 to get our gemnasium badge back to green
