### PR TITLE
Fix country selector in Sponsor New/Edit

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -96,7 +96,7 @@ ActiveAdmin.register Sponsor do
       end
       f.input :payment_plan, as: :select, collection: Sponsor::PAYMENT_PLANS, include_blank: true
       f.input :country, as: :country,
-              priority_countries: %w(SA TR AE GB), except: ['IL'], selected: 'SA'
+              priority_countries: %w(SA TR AE GB), except: ['IL']
       f.input :city, as: :select,
               collection: Sponsor.all_cities.unshift(Sponsor::NEW_CITY_MENU_OPTION),
               include_blank: false

--- a/features/admin/sponsor.feature
+++ b/features/admin/sponsor.feature
@@ -140,7 +140,7 @@ Feature:
     And I am on the "Show Sponsor" page for sponsor "Sponsor1"
     Then "Agent One" should link to the "Show" page for user "Agent One"
 
- Scenario: Should return to sponsor show page when edit sponsor is cancelled
+  Scenario: Should return to sponsor show page when edit sponsor is cancelled
     Given I am on the "Show Sponsor" page for sponsor "Sponsor1"
     And I click the "Edit Sponsor" button
     And I select "Canada" from the drop down box for "Country"
@@ -165,3 +165,7 @@ Feature:
     And I click the "Update Sponsor" button
     When I am on the "New Sponsor" page for the "Admin" role
     Then the "City" selector for this sponsor should contain "Saint-Louis-du-Ha! Ha!"
+
+  Scenario: **Bug fix** When editing a sponsor, country selector defaults to sponsor's country
+    Given I am on the "Edit Sponsor" page for sponsor "Sponsor1"
+    Then the drop down box for "Country" should show "United Kingdom"

--- a/features/step_definitions/admin/sponsors_steps.rb
+++ b/features/step_definitions/admin/sponsors_steps.rb
@@ -65,3 +65,8 @@ Then /^the "([^"]*)" selector for this (sponsor|partner|orphan|user) should cont
   selector = "#{model}_#{selector_name.parameterize}"
   expect(page).to have_select(selector, with_options: [option])
 end
+
+Then /^the drop down box for "([^"]*)" should show "([^"]*)"$/ do |selector, value|
+  element_id = "sponsor_#{selector.parameterize('_')}"
+  expect(page).to have_select(element_id, selected: value)
+end


### PR DESCRIPTION
**Quick action appreciated, this is already on staging**

The country selector defaults to Saudi Arabia regardless of sponsor's country. Thus, going to Edit and clicking 'Update' changes the country to SA.

_There is also a bug where Andorra is displayed as Andorre in the drop-down selector, but as Andorra in the show view. Probably not a big source of concern._
