### PR TITLE
Fix bug in sponsored_minor_siblings_count validator

### DIFF
--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -27,7 +27,7 @@ class Orphan < ActiveRecord::Base
   validates :contact_number, presence: true
   validates :sponsored_by_another_org, inclusion: {in: [true, false] }, exclusion: { in: [nil]}
   validates :minor_siblings_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :sponsored_minor_siblings_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :sponsored_minor_siblings_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validate :sponsored_siblings_does_not_exceed_siblings_count
   validates :original_address, presence: true
   validates :current_address, presence: true
@@ -110,7 +110,7 @@ class Orphan < ActiveRecord::Base
   private
 
   def sponsored_siblings_does_not_exceed_siblings_count
-    if sponsored_minor_siblings_count > minor_siblings_count
+    if sponsored_minor_siblings_count && (sponsored_minor_siblings_count > minor_siblings_count)
       errors.add(:sponsored_minor_siblings_count, "cannot exceed minor siblings count")
     end
   end

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -59,7 +59,7 @@ describe Orphan, type: :model do
   it { is_expected.to_not allow_value(nil).for(:sponsored_by_another_org) }
 
   it { is_expected.to validate_numericality_of(:minor_siblings_count).only_integer.is_greater_than_or_equal_to(0) }
-  it { is_expected.to validate_numericality_of(:sponsored_minor_siblings_count).only_integer.is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_numericality_of(:sponsored_minor_siblings_count).only_integer.is_greater_than_or_equal_to(0).allow_nil }
 
   it { is_expected.to validate_presence_of :original_address }
   it { is_expected.to validate_presence_of :current_address }
@@ -113,6 +113,11 @@ describe Orphan, type: :model do
     it "is not valid when sponsored siblings exceeds siblings count" do
       orphan.sponsored_minor_siblings_count = 3
       expect(orphan).not_to be_valid
+    end
+
+    it 'is valid when sponsored_minor_siblings_count is not specified (bug fix)' do
+      orphan.sponsored_minor_siblings_count = nil
+      expect(orphan).to be_valid
     end
   end
 


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-271

`sponsored_minor_siblings_count` is an optional attribute, and the validator breaks when it is not specified
