### PR TITLE
Add sponsorship start date for the currently sponsored orphan(s) table

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -56,7 +56,7 @@ ActiveAdmin.register Sponsor do
         column :orphan_date_of_birth
         column :orphan_gender
         column 'Sponsorship began' do |_sponsorship|
-          _sponsorship.start_date.strftime("%B %Y")
+          _sponsorship.start_date.strftime("%m/%Y")
         end
         column '' do |_sponsorship|
           form_submit_route= inactivate_admin_sponsor_sponsorship_path(sponsor_id: sponsor.id, id: _sponsorship.id)
@@ -78,10 +78,10 @@ ActiveAdmin.register Sponsor do
         column :orphan_date_of_birth
         column :orphan_gender
         column 'Sponsorship began' do |_sponsorship|
-          _sponsorship.start_date.strftime("%B %Y")
+          _sponsorship.start_date.strftime("%m/%Y")
         end
         column 'Sponsorship ended' do |_sponsorship|
-          _sponsorship.end_date.strftime("%B %Y")
+          _sponsorship.end_date.strftime("%m/%Y")
         end
       end
     end

--- a/features/admin/sponsorship.feature
+++ b/features/admin/sponsorship.feature
@@ -64,7 +64,7 @@ Feature:
     And I should see "Sponsorship link was successfully terminated"
     And I should not see "First Orphan" within "Currently Sponsored Orphans"
     And I should see "First Orphan" within "Previously Sponsored Orphans"
-    And I should see "March 2014" within "Previously Sponsored Orphans"
+    And I should see "03/2014" within "Previously Sponsored Orphans"
 
   Scenario: Currently sponsored orphans should not be eligible for any new sponsorships
     Given an active sponsorship link exists between sponsor "First Sponsor" and orphan "First Orphan"


### PR DESCRIPTION
Just a simple copypaste of three lines of code from the Previously Sponsored Orphans table in the Sponsor view, which already has this column.
