### PR TITLE
graceful handling of case where no orphan list spreadsheet specified

### DIFF
--- a/app/admin/pending_orphan_list.rb
+++ b/app/admin/pending_orphan_list.rb
@@ -30,6 +30,11 @@ ActiveAdmin.register PendingOrphanList do
       redirect_to admin_partner_path(params[:partner_id])
       return
     end
+    if params['pending_orphan_list'].nil?  # no spreadsheet has been specified
+      flash[:error] = 'Please specify the spreadsheet to be uploaded'
+      redirect_to upload_admin_partner_pending_orphan_lists_path(params[:partner_id]) # ie same page
+      return
+    end
     @pending_orphan_list = PendingOrphanList.new(pending_orphan_list_params)
     importer             = OrphanImporter.new(params['pending_orphan_list']['spreadsheet'])
     result               = importer.extract_orphans

--- a/features/admin/orphan_lists.feature
+++ b/features/admin/orphan_lists.feature
@@ -63,6 +63,13 @@ Feature:
     Then I should see "is invalid"
     And I should not see the "Import" link
 
+  Scenario: I should not be able to upload if I haven't specified an orphan list file
+    Given I visit the new orphan list page for partner "Partner1"
+    And I click the "Upload" button    
+    Then I should see "Upload"
+    And I should see "Please specify"
+    And I should not see the "Import" link
+
   Scenario: I should be able to upload a valid .xls orphan list file
     Given I visit the new orphan list page for partner "Partner1"
     And I upload the "one_orphan_xls.xls" file

--- a/spec/controllers/admin/pending_orphan_lists_controller_spec.rb
+++ b/spec/controllers/admin/pending_orphan_lists_controller_spec.rb
@@ -54,6 +54,19 @@ describe Admin::PendingOrphanListsController, type: :controller do
       end
     end
 
+    context 'when no spreadsheet is specified' do
+
+      before do
+        allow(partner).to receive(:active?).and_return true
+        post :validate, partner_id: 1
+      end
+
+      it 'redirects back to the current page' do
+        expect(response).to redirect_to upload_admin_partner_pending_orphan_lists_path(1)
+      end
+      
+    end
+
     context 'when partner is active' do
       let(:orphan_list_params) { { spreadsheet: fixture_file_upload('one_orphan_xls.xls') } }
 


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-285 
When the user clicks on Upload orphan list spreadsheet, but hasn't specified the spreadsheet file, then the application generates a flash error message, and returns to the same page.
Changes to the admin pending_orphan_list controller, and corresponding rspec and cucumber tests.
