### PR TITLE
OSRA-300 - refine Orphan#full_name

### DIFF
--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -79,7 +79,7 @@ class Orphan < ActiveRecord::Base
   # end TODO
 
   def full_name
-    "#{name} #{family_name}"
+    "#{name} #{father_given_name} #{family_name}"
   end
 
   def orphans_dob_within_1yr_of_fathers_death

--- a/features/admin/orphans.feature
+++ b/features/admin/orphans.feature
@@ -16,7 +16,7 @@ Feature:
 
   Scenario: There should be a list of orphans on the admin index page
     Given I am on the "Orphans" page for the "Admin" role
-    Then I should see "Orphan 1 1"
+    Then I should see "Orphan 1 Father 1"
     And I should see the OSRA number for "Orphan 1"
     And I should see "Orphan Status" for "Orphan 1" set to "Active"
     And I should see "Date of Birth" for "Orphan 1" set to "January 01, 2012"
@@ -25,7 +25,7 @@ Feature:
     And I should see "Gender" for "Orphan 1" set to "Female"
     And I should see "Priority" for "Orphan 1" set to "Normal"
     And I should see "Sponsorship" for "Orphan 1" set to "Sponsored"
-    And I should see "Orphan 2 2"
+    And I should see "Orphan 2 Father 2"
 
   Scenario: Should not be able to create new orphans directly via the UI
     When I am on the "Orphans" page for the "Admin" role
@@ -83,7 +83,7 @@ Feature:
     Then I should be on the "Show Orphan" page for orphan "Orphan N"
     And I should see "Orphan was successfully updated"
     And I should see the OSRA number for "Orphan N"
-    And I should see "Orphan N N"
+    And I should see "Orphan N Father N"
     And I should see "Date Of Birth" set to "January 01, 2010"
     And I should see "Goes To School" set to "No"
     And I should see "Father Occupation" set to "Another Occupation"

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -317,9 +317,11 @@ describe Orphan, type: :model do
 
       describe 'methods' do
 
-        specify '#full_name combines name & family_name' do
-          orphan = Orphan.new(name: 'Bart', family_name: 'Simpson')
-          expect(orphan.full_name).to eq 'Bart Simpson'
+        specify '#full_name combines name, father_given_name & family_name' do
+          orphan = Orphan.new(name: 'Bart',
+                              father_given_name: 'Homer',
+                              family_name: 'Simpson')
+          expect(orphan.full_name).to eq 'Bart Homer Simpson'
         end
 
         describe '#update_sponsorship_status!' do


### PR DESCRIPTION
OSRA-304 - change implementation of Orphan#full_name
- based on clarification from client, change the method to compose
  an orphan's `full_name` out of `name`, `father_given_name` and `family_name`
- revert orphans.feature to original
