### PR TITLE
prevent rake sending status to std out when being tested

### DIFF
--- a/spec/lib/rake/clear_orphans_rake_spec.rb
+++ b/spec/lib/rake/clear_orphans_rake_spec.rb
@@ -14,7 +14,9 @@ describe 'rake db:clear_orphans' do
     2.times { FactoryGirl.create :sponsorship, sponsor: two_sponsor }
     FactoryGirl.create :sponsorship, sponsor: one_sponsor
 
-    Rake::Task['db:clear_orphans'].invoke
+    silence_stream(STDOUT) do
+      Rake::Task['db:clear_orphans'].invoke
+    end
   end
 
   it 'deletes all relevant records and resets request_fulfilled attributes' do


### PR DESCRIPTION
this implementation used in preference to wrapping in a quietly block
becauase the quietly block silences std err as well.
