### PR TITLE
OSRA-300 split `father_name`: cleanup

### DIFF
--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -66,16 +66,9 @@ class Orphan < ActiveRecord::Base
   accepts_nested_attributes_for :current_address, allow_destroy: true
   accepts_nested_attributes_for :original_address, allow_destroy: true
 
-  # begin TODO remove temporary methods after OSRA-300 finished
   def father_name
     "#{father_given_name} #{family_name}"
   end
-
-  def father_name= (full_name)
-    return false unless full_name
-    self.father_given_name, self.family_name = full_name.split(' ', 2)
-  end
-  # end TODO
 
   def full_name
     "#{name} #{father_given_name} #{family_name}"

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -31,24 +31,6 @@ describe Orphan, type: :model do
       to include 'An orphan with this name, father, mother & family name is already in the database.'
   end
 
-  # begin TODO remove temporary code after OSRA-300 finished
-  # it { is_expected.to validate_presence_of :father_name }
-  describe 'temporary methods' do
-    let(:orphan) { Orphan.new }
-
-    specify '#father_name composes full name' do
-      orphan.father_given_name = 'Homer Jay'
-      orphan.family_name = 'Simpson'
-      expect(orphan.father_name).to eq 'Homer Jay Simpson'
-    end
-
-    specify '#father_name= decomposes full name into first & last' do
-      orphan.father_name = 'Homer Jay Simpson'
-      expect(orphan.father_given_name).to eq 'Homer'
-      expect(orphan.family_name).to eq 'Jay Simpson'
-    end
-  end
-  # end TODO
 
   it { is_expected.to validate_presence_of :father_given_name }
   it { is_expected.to validate_presence_of :family_name }
@@ -316,11 +298,20 @@ describe Orphan, type: :model do
 
       describe 'methods' do
 
-        specify '#full_name combines name, father_given_name & family_name' do
-          orphan = Orphan.new(name: 'Bart',
-                              father_given_name: 'Homer',
-                              family_name: 'Simpson')
-          expect(orphan.full_name).to eq 'Bart Homer Simpson'
+        describe 'name methods' do
+          let(:orphan) do
+            Orphan.new(name: 'Bart',
+                       father_given_name: 'Homer',
+                       family_name: 'Simpson')
+          end
+
+          specify '#father_name combines father_given_name & family_name' do
+            expect(orphan.father_name).to eq 'Homer Simpson'
+          end
+
+          specify '#full_name combines name, father_given_name & family_name' do
+            expect(orphan.full_name).to eq 'Bart Homer Simpson'
+          end
         end
 
         describe '#update_sponsorship_status!' do


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-307
OSRA-307 clean up temporary methods
- remove `Orphan#father_name=` & spec
- retain `Orphan#father_name` (used in many views) & clean up spec
