### PR TITLE
OSRA-311 Remove trailing .0 from contact numbers

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -178,11 +178,11 @@ import:
     - field: contact_number
       column: AE
       mandatory: true
-      type: String
+      type: NotAFloat
     - field: alt_contact_number
       column: AF
       mandatory: false
-      type: String
+      type: NotAFloat
     - field: sponsored_by_another_org
       column: AG
       mandatory: true

--- a/features/admin/orphan_lists.feature
+++ b/features/admin/orphan_lists.feature
@@ -160,6 +160,13 @@ Feature:
     Then I go to the "Orphans" page for the "Admin" role
     Then I should see "الكركيري"
 
+  Scenario: Contact numbers should not be stored as floats
+    Given I have already uploaded the "three_orphans_xlsx.xlsx" file for partner "Partner1"
+    When I go to the "Orphans" page for the "Admin" role
+    And I click the "1300001" link
+    Then I should see "963943235556"
+    And I should not see "963943235556.0"
+
   Scenario: I should not be able to import orphan records that fail validations
     Given I have already uploaded the "one_orphan_xlsx.xlsx" file for partner "Partner1"
     And I try to upload the "one_orphan_xlsx.xlsx" file for partner "Partner1" again

--- a/lib/import_orphan_settings.rb
+++ b/lib/import_orphan_settings.rb
@@ -90,6 +90,13 @@ class ImportOrphanSettings
   end
   class ProvinceColumn < ImportOrphanSettings::DataColumn
   end
+  class NotAFloatColumn < ImportOrphanSettings::DataColumn
+    def to_val
+      raise_error_if_mandatory_and_blank?
+      return if @column_value.blank?
+      @column_value.to_s.gsub(/\A(\d+)\.0\z/, '\1')
+    end
+  end
 
   def self.settings
     Settings.import

--- a/spec/lib/orphan_importer_spec.rb
+++ b/spec/lib/orphan_importer_spec.rb
@@ -135,6 +135,27 @@ describe OrphanImporter do
       expect(one_orphan_importer.send(:process_column, record,
                                       column, "#{date}")).to eq date
     end
+
+    describe 'NotAFloat' do
+      before(:each) do
+        expect(column).to receive(:mandatory).and_return('false').at_least(:once)
+        expect(column).to receive(:type).and_return('NotAFloat').at_least(:once)
+      end
+
+      it 'will strip trailing .0 from values that should be integers' do
+        [1.0, 123.0, 1234567890.0].each do |float|
+          expect(one_orphan_importer.send(:process_column, record,
+                                          column, float)).to eq float.to_i.to_s
+        end
+      end
+
+      it 'will let strings pass through unaltered' do
+        %w{1.01 1.10 a1.0 a.1.0}.each do |string|
+          expect(one_orphan_importer.send(:process_column, record,
+                                          column, string)).to eq string
+        end
+      end
+    end
   end
 
   describe '#error_or_orphans' do


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-311
- define NotAFloat column data type in the importer that strips trailing .0
  from strings that otherwise only contain digits
- replace String with NotAFloat for `contact_number` & `alt_contact_number`
  columns
- spec & scenario
