### PR TITLE
OSRA-313 Re-enable RSpec config

### DIFF
--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -385,7 +385,7 @@ describe Orphan, type: :model do
 
             describe 'for orphans with sponsorships' do
               let(:orphan) { on_hold_sponsored_orphan }
-              let(:sponsorships) { ['not empty'] }
+              let(:sponsorships) { double(:empty? => false) }
 
               it 'sets sponsorship_status to Previously Sponsored when status -> Active for previously sponsored orphan' do
                 expect(orphan).to receive(:sponsorships).at_least(:once).and_return sponsorships

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ Coveralls.wear_merged! 'rails'
 RSpec.configure do |config|
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
@@ -40,7 +40,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -76,5 +76,4 @@ RSpec.configure do |config|
     # a real object. This is generally recommended.
     mocks.verify_partial_doubles = true
   end
-=end
 end


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-313
- uncomment config settings in spec/spec_helper.rb
- fix failures in orphan_spec that resulted from enabling
  `mocks.verify_partial_doubles = true` (L77)

OSRA-313 #Code-Review
