### PR TITLE
O317 - Add header for flash messages

### DIFF
--- a/app/helpers/_flashes_helper.rb
+++ b/app/helpers/_flashes_helper.rb
@@ -1,12 +1,22 @@
 module FlashesHelper
-  
+
+  ACCEPTED_FLASH_HTML_CLASSES = {
+    success: 'alert alert-success',
+    error: 'alert alert-danger'
+  }  
+
   def flash_htmlclass_for type
-    case type.to_sym 
-      when :success 
-        'alert alert-success'
-      when :error
-        'alert alert-danger'
+    ACCEPTED_FLASH_HTML_CLASSES[type.to_sym] || nil
+  end
+
+  def each_accepted_flash
+    flash.each do |fl|
+      yield fl if flash_htmlclass_for fl[0]
     end
+  end
+
+  def any_accepted_flash?
+    flash.any? {|k,_| flash_htmlclass_for k }
   end
 
 end

--- a/app/helpers/_flashes_helper.rb
+++ b/app/helpers/_flashes_helper.rb
@@ -1,0 +1,12 @@
+module FlashesHelper
+  
+  def flash_htmlclass_for type
+    case type.to_sym 
+      when :success 
+        'alert alert-success'
+      when :error
+        'alert alert-danger'
+    end
+  end
+
+end

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -1,7 +1,12 @@
-<% unless flash.empty? %>
+<% if any_accepted_flash? %>
   <div class="flashes">
-    <% flash.each do |type, message| %>
-      <div class="<%= flash_htmlclass_for type %>"><%= message.to_s %></div>
+    <% each_accepted_flash do |type, message| %>
+      <div class="<%= flash_htmlclass_for type %>">
+        <%= button_to "#", :class => "close", "data-dismiss" => "alert", :aria_label => "Close" do %>
+          <span aria-hidden="true">&times;</span>
+        <% end %>
+        <%= message.to_s %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -1,0 +1,7 @@
+<% unless flash.empty? %>
+  <div class="flashes">
+    <% flash.each do |type, message| %>
+      <div class="<%= flash_htmlclass_for type %>"><%= message.to_s %></div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   </head>
   <body>
     <div class="container-fluid">
+      <%= render 'layouts/flashes' %>
       <%= yield %>
       <%= render 'layouts/footer' %>
     </div>

--- a/spec/views/layouts/_flashes_spec.rb
+++ b/spec/views/layouts/_flashes_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'layouts/_flashes.html.erb', type: :view do
+  context 'flash messages defined' do
+    let(:flash_success) {flash[:success] = 'Success message!'}
+    let(:flash_error) {flash[:error] = 'Error message!'}
+    
+    it 'should show flash messages' do
+      flash_success and flash_error
+      render
+      expect(rendered).to have_selector '.flashes'
+      expect(rendered).to match /Success message!/
+      expect(rendered).to match /Error message!/
+    end
+  end
+
+  context 'no flash messages defined' do
+    it 'should not show flash messages' do
+      render
+      expect(rendered).to_not have_selector '.flashes'
+    end
+  end
+end

--- a/spec/views/layouts/_flashes_spec.rb
+++ b/spec/views/layouts/_flashes_spec.rb
@@ -4,13 +4,21 @@ RSpec.describe 'layouts/_flashes.html.erb', type: :view do
   context 'flash messages defined' do
     let(:flash_success) {flash[:success] = 'Success message!'}
     let(:flash_error) {flash[:error] = 'Error message!'}
+    let(:flash_other) {flash[:other] = 'Other message!'}
     
-    it 'should show flash messages' do
+    it 'should show accepted flash messages' do
       flash_success and flash_error
       render
       expect(rendered).to have_selector '.flashes'
       expect(rendered).to match /Success message!/
       expect(rendered).to match /Error message!/
+    end
+
+    it 'should not show unaccepted flash messages' do
+      flash_other
+      render
+      expect(rendered).to_not have_selector '.flashes'
+      expect(rendered).to_not match /Other message!/
     end
   end
 


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-317

Created _flash.html.erb partial to display success and error flash messages.
+ rspec tests

To show a flash masseges anywhere in the rails views just use:

flash[:success] = "Partner saved"       or
flash[:error] = "Partner failed to save"       or use the form validation errors instead
