### PR TITLE
URGENT fix for osra orphan import requested by client

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,7 +2,7 @@ class Address < ActiveRecord::Base
 
   validates :province, presence: true
   validates :city, presence: true
-  validates :neighborhood, presence: true
+  #validates :neighborhood, presence: true
 
   belongs_to :province
 end

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -38,7 +38,7 @@ class Orphan < ActiveRecord::Base
   validates :gender, presence: true, inclusion: {in: Settings.lookup.gender }
   validates :contact_number, presence: true
   validates :sponsored_by_another_org, inclusion: {in: [true, false] }, exclusion: { in: [nil]}
-  validates :minor_siblings_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :minor_siblings_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 },  allow_nil: true
   validates :sponsored_minor_siblings_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validate :sponsored_siblings_does_not_exceed_siblings_count
   validates :original_address, presence: true
@@ -127,6 +127,12 @@ class Orphan < ActiveRecord::Base
 private
 
   def sponsored_siblings_does_not_exceed_siblings_count
+    if minor_siblings_count.nil?
+      unless sponsored_minor_siblings_count == 0 or sponsored_minor_siblings_count.nil?
+        errors.add(:sponsored_minor_siblings_count, "cannot exceed minor siblings count")
+      end
+      return
+    end
     if sponsored_minor_siblings_count && (sponsored_minor_siblings_count > minor_siblings_count)
       errors.add(:sponsored_minor_siblings_count, "cannot exceed minor siblings count")
     end

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -127,15 +127,10 @@ class Orphan < ActiveRecord::Base
 private
 
   def sponsored_siblings_does_not_exceed_siblings_count
-    if minor_siblings_count.nil?
-      unless sponsored_minor_siblings_count == 0 or sponsored_minor_siblings_count.nil?
-        errors.add(:sponsored_minor_siblings_count, "cannot exceed minor siblings count")
-      end
-      return
-    end
-    if sponsored_minor_siblings_count && (sponsored_minor_siblings_count > minor_siblings_count)
-      errors.add(:sponsored_minor_siblings_count, "cannot exceed minor siblings count")
-    end
+   return if sponsored_minor_siblings_count.nil? || sponsored_minor_siblings_count == 0
+   if minor_siblings_count.nil? || sponsored_minor_siblings_count > minor_siblings_count
+     errors.add(:sponsored_minor_siblings_count, 'cannot exceed minor siblings count')
+   end
   end
 
   def default_sponsorship_status_unsponsored

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -133,7 +133,7 @@ import:
       type: String
     - field: guardian_id_num
       column: T
-      mandatory: true
+      mandatory: false
       type: Integer
     - field: original_address_province
       column: U
@@ -145,7 +145,7 @@ import:
       type: String
     - field: original_address_neighborhood
       column: W
-      mandatory: true
+      mandatory: false
       type: String
     - field: original_address_street
       column: X
@@ -165,7 +165,7 @@ import:
       type: String
     - field: current_address_neighborhood
       column: AB
-      mandatory: true
+      mandatory: false
       type: String
     - field: current_address_street
       column: AC
@@ -193,7 +193,7 @@ import:
       type: String
     - field: minor_siblings_count
       column: AI
-      mandatory: true
+      mandatory: false
       type: Integer
     - field: sponsored_minor_siblings_count
       column: AJ

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -10,7 +10,7 @@ describe Address, type: :model do
 
   it { is_expected.to validate_presence_of :city }
 
-  it { is_expected.to validate_presence_of :neighborhood }
+  #it { is_expected.to validate_presence_of :neighborhood }
 
   it { is_expected.to belong_to :province }
 end

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -53,7 +53,7 @@ describe Orphan, type: :model do
 
   it { is_expected.to_not allow_value(nil).for(:sponsored_by_another_org) }
 
-  it { is_expected.to validate_numericality_of(:minor_siblings_count).only_integer.is_greater_than_or_equal_to(0) }
+  #it { is_expected.to validate_numericality_of(:minor_siblings_count).only_integer.is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_numericality_of(:sponsored_minor_siblings_count).only_integer.is_greater_than_or_equal_to(0).allow_nil }
 
   it { is_expected.to validate_presence_of :original_address }
@@ -141,6 +141,26 @@ describe Orphan, type: :model do
     it 'is valid when sponsored_minor_siblings_count is not specified (bug fix)' do
       orphan.sponsored_minor_siblings_count = nil
       expect(orphan).to be_valid
+    end
+
+    describe 'if sibling count nil then sponsored sibling count is nil or 0' do
+      it 'is valid when sibling count nil' do
+        orphan.minor_siblings_count = nil
+        orphan.sponsored_minor_siblings_count = nil
+        expect(orphan).to be_valid
+      end
+
+      it 'is valid when sibling count 0' do
+        orphan.minor_siblings_count = nil
+        orphan.sponsored_minor_siblings_count = 0
+        expect(orphan).to be_valid
+      end
+
+      it 'is not valid when sibling count greater than 0' do
+        orphan.minor_siblings_count = nil
+        orphan.sponsored_minor_siblings_count = 1
+        expect(orphan).not_to be_valid
+      end
     end
   end
 

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -143,20 +143,20 @@ describe Orphan, type: :model do
       expect(orphan).to be_valid
     end
 
-    describe 'if sibling count nil then sponsored sibling count is nil or 0' do
-      it 'is valid when sibling count nil' do
+    context 'when minor_sibling_count is nil' do
+      it 'is valid when sponsored_minor_siblings_count is nil' do
         orphan.minor_siblings_count = nil
         orphan.sponsored_minor_siblings_count = nil
         expect(orphan).to be_valid
       end
 
-      it 'is valid when sibling count 0' do
+      it 'is valid when sponsored_minor_siblings_count is 0' do
         orphan.minor_siblings_count = nil
         orphan.sponsored_minor_siblings_count = 0
         expect(orphan).to be_valid
       end
 
-      it 'is not valid when sibling count greater than 0' do
+      it 'is not valid when sponsored_minor_siblings_count is greater than 0' do
         orphan.minor_siblings_count = nil
         orphan.sponsored_minor_siblings_count = 1
         expect(orphan).not_to be_valid


### PR DESCRIPTION
- removed mandatory status on attributes
  - minor_siblings_count
  - original neighbourhood
  - current neighbourhood
  - guardian id num
- validations that just need to be removed have been only commented out given
  that the request suggest this is only temporary
- no major attempt to refactor minor sibling count cross validation again given
  the temporary nature of the issue
- additional tests for the cross validation of sibling count
- changed config/settings.yml to remove mandatory status from fields