### PR TITLE
add bootstrap-date-picker rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'pg'
 gem 'sass-rails', '~> 5.0.0'
 # sass powered version of bootstrap https://github.com/twbs/bootstrap-sass
 gem 'bootstrap-sass', '~> 3.3.1'
+# jquery datepicker and bootstrap-sass gem don't play nicely
+gem 'bootstrap-datepicker-rails'
 # gem to add browser vendor prefixes automatically. Recommended install for
 # bootstrap-sass
 gem 'autoprefixer-rails', '~> 4.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-datepicker-rails (1.3.1.1)
+      railties (>= 3.0)
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     bourbon (4.0.2)
@@ -331,6 +333,7 @@ DEPENDENCIES
   aws-sdk
   better_errors
   binding_of_caller
+  bootstrap-datepicker-rails
   bootstrap-sass (~> 3.3.1)
   capybara
   capybara-webkit

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,4 +12,5 @@
 //
 //= require_tree .
 //= require jquery
+//= require bootstrap-datepicker
 //= require bootstrap-sprockets


### PR DESCRIPTION
extracted out from #252 to make the gem addition a clean separate commit
- https://github.com/Nerian/bootstrap-datepicker-rails
- jquery ui datepicker and bootstrap sass don't play nicely
- seems active based upon size of actual gem activity as recent as late Dec 2014, but please check and decide   for yourselves.