### PR TITLE
fixed display of father name in orphan import OSRA-324

### DIFF
--- a/app/models/pending_orphan.rb
+++ b/app/models/pending_orphan.rb
@@ -3,6 +3,10 @@ class PendingOrphan < ActiveRecord::Base
   after_initialize :create_orphan
   attr_accessor :orphan
 
+  def father_name
+    "#{father_given_name} #{family_name}"
+  end
+  
   def create_orphan
     @orphan = Orphan.new
   end

--- a/features/admin/orphan_lists.feature
+++ b/features/admin/orphan_lists.feature
@@ -152,6 +152,15 @@ Feature:
     Then I click the "Cancel" button
     Then I should be on the "Show Partner" page for partner "Partner1"
 
+  Scenario: I should be able to see summary details of the orphans to import
+    Given I visit the new orphan list page for partner "Partner1"
+    And I upload the "one_orphan_xlsx.xlsx" file
+    Then I click the "Upload" button
+    Then I should see "محمد"
+    And I should see "John Doe"
+    And I should see "January 02, 2012"
+    And I should see "Male"
+
   Scenario: I should be able to see the imported orphans
     Given I visit the new orphan list page for partner "Partner1"
     And I upload the "three_orphans_xlsx.xlsx" file


### PR DESCRIPTION
pending_orphan model fixed to include father_name from father_given_name and family_name,
plus a cucumber test to check that the orphan import display includes the correct attributes.