### PR TITLE
Osra 347 fix sponsorship validation conditional

### DIFF
--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -12,7 +12,7 @@ class Sponsorship < ActiveRecord::Base
   validates :start_date, presence: { scope: true, message: "is invalid"}
   validate  :start_date_no_later_than_1st_of_next_month, if: :start_date
   
-  validates :end_date, presence: {scope: true, message: 'is invalid' }, if: '!active', if: 'active_changed?'
+  validates :end_date, presence: { message: 'is invalid' }, if: '!active'
   validate  :end_date_not_before_start_date, on: :update, if: :end_date
 
   validates :orphan, uniqueness: { scope: :active,

--- a/spec/models/sponsorship_spec.rb
+++ b/spec/models/sponsorship_spec.rb
@@ -67,7 +67,7 @@ describe Sponsorship, type: :model do
       it { is_expected.to_not allow_value(start_date - 1).for :end_date }
       it { is_expected.to allow_value(start_date).for :end_date }
  
-      ["", "42", "5-12"].each do |bad_date|
+      [nil, "", "42", "5-12"].each do |bad_date|
         it { is_expected.to_not allow_value(bad_date).for :end_date }
       end 
     end 


### PR DESCRIPTION
OSRA-347 Fix sponsorship.rb end_date validation

https://osraav.atlassian.net/browse/OSRA-347

_This PR is based on #270, but can be rebased on develop if needed_

 - replace double conditional with single `if: '!active'` - end date must
   always be present when sponsorship is inactive, not only at the moment
   the inactivation takes place
 - add `nil` as an unacceptable value for inactive sponsorship's `end_date`
   in sponsorship_spec.rb