### PR TITLE
OSRA-351 Display full country names in filter

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -6,8 +6,11 @@ ActiveAdmin.register Sponsor do
   filter :status, as: :select, collection: proc { Status.pluck(:name, :id) }
   filter :sponsor_type, as: :select, collection: proc { SponsorType.pluck(:name, :id) }
   filter :agent, as: :select, collection: proc { User.pluck(:user_name, :id) }
-  filter :country, as: :select,
-         collection: proc {Sponsor.distinct.pluck :country}
+  filter :country, as: :select, collection: proc {
+    Sponsor.distinct.pluck(:country).each_with_object({}) do |c, h|
+      h[ISO3166::Country[c].name] = c
+    end
+  }
   filter :city, as: :select, collection: proc { Sponsor.distinct.pluck(:city).uniq.sort }
   filter :created_at, as: :date_range
   filter :updated_at, as: :date_range

--- a/features/aa/aa_features/sponsor.feature
+++ b/features/aa/aa_features/sponsor.feature
@@ -169,3 +169,7 @@ Feature:
   Scenario: **Bug fix** When editing a sponsor, country selector defaults to sponsor's country
     Given I am on the "Edit Sponsor" page for sponsor "Sponsor1"
     Then the drop down box for "Country" should show "United Kingdom"
+
+  Scenario: **Bug fix** Country filter list should show full country names
+    Given I am on the "Sponsors" page for the "Admin" role
+    Then I should see full country names in the Country filter

--- a/features/aa/step_definitions/aa_steps/sponsors_steps.rb
+++ b/features/aa/step_definitions/aa_steps/sponsors_steps.rb
@@ -81,3 +81,8 @@ Then /^the drop down box for "([^"]*)" should show "([^"]*)"$/ do |selector, val
   element_id = "sponsor_#{selector.parameterize('_')}"
   expect(page).to have_select(element_id, selected: value)
 end
+
+Then /^I should see full country names in the Country filter$/ do
+  countries = Sponsor.distinct.pluck(:country).map { |c| ISO3166::Country[c] }
+  expect(page).to have_select('q_country', with_options: countries)
+end


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-351

Original filter only displayed 2-letter country codes that are stored with the sponsor record. The new implementation provides the filter with a hash that maps those codes to full country names.