### PR TITLE
OSRA-363 OSRA-364 Default translation values

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register Sponsor do
     column :request_fulfilled
     column :sponsor_type
     column :country do |_sponsor|
-      "(#{ISO3166::Country[_sponsor.country]}) #{t _sponsor.country, locale: :ar}"
+      en_ar_country(_sponsor.country)
     end
   end
 
@@ -51,7 +51,7 @@ ActiveAdmin.register Sponsor do
       row :sponsor_type
       row :affiliate
       row :country do |_sponsor|
-        "(#{ISO3166::Country[_sponsor.country]}) #{t _sponsor.country, locale: :ar}"
+        en_ar_country(_sponsor.country)
       end
       row :city
       row :address

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -28,7 +28,9 @@ ActiveAdmin.register User do
           link_to sponsor.name, admin_sponsor_path(sponsor)
         end
         column :gender
-        column :country
+        column :country do |_sponsor|
+          en_ar_country(_sponsor.country)
+        end
         column :status
         column :request_fulfilled
         column 'Orphans sponsored' do |_sponsor|

--- a/app/helpers/admin/country_helper.rb
+++ b/app/helpers/admin/country_helper.rb
@@ -1,0 +1,11 @@
+module Admin::CountryHelper
+
+  def en_ar_country(country)
+    en_country = ISO3166::Country[country]
+    ar_country = I18n.with_locale :ar do
+      t country, default: :missing
+    end
+
+    ("(#{en_country}) #{ar_country}").html_safe
+  end
+end

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -223,3 +223,5 @@ ar:
   YE: اليمن
   ZM: زامبيا
   ZW: زمبابوي
+
+  missing: <em>[Translation N/A]</em>

--- a/features/aa/aa_features/sponsor.feature
+++ b/features/aa/aa_features/sponsor.feature
@@ -173,3 +173,10 @@ Feature:
   Scenario: **Bug fix** Country filter list should show full country names
     Given I am on the "Sponsors" page for the "Admin" role
     Then I should see full country names in the Country filter
+
+  Scenario: **Bug fix** Display 'Translation N/A' when translation missing
+    Given "Obscure Sponsor" is from Cayman Islands-KY
+    And I am on the "Sponsors" page for the "Admin" role
+    Then I should see "(Cayman Islands) [Translation N/A]"
+    When I am on the "Show Sponsor" page for sponsor "Obscure Sponsor"
+    Then I should see "(Cayman Islands) [Translation N/A]"

--- a/features/aa/step_definitions/aa_steps/sponsors_steps.rb
+++ b/features/aa/step_definitions/aa_steps/sponsors_steps.rb
@@ -86,3 +86,7 @@ Then /^I should see full country names in the Country filter$/ do
   countries = Sponsor.distinct.pluck(:country).map { |c| ISO3166::Country[c] }
   expect(page).to have_select('q_country', with_options: countries)
 end
+
+Given /^"([^"]*)" is from (?:.*)-([A-Z]{2})$/ do |name, country_code|
+  FactoryGirl.create(:sponsor, name: name, country: country_code)
+end

--- a/spec/helpers/admin/country_helper_spec.rb
+++ b/spec/helpers/admin/country_helper_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Admin::CountryHelper, type: :helper do
+  specify '#en_ar_country returns "(English) Arabic"' do
+    expect(helper.en_ar_country('TR')).to eq '(Turkey) تركيا'
+  end
+end


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-363
https://osraav.atlassian.net/browse/OSRA-364

AA: Provide global default of _[Translation N/A]_ to handle cases where Arabic translation is missing in Sponsor index & show and User show views. Prefer this to an empty string to make such cases easily identifiable for possible fixing.
![screen shot 2015-01-17 at 11 20 21 pm](https://cloud.githubusercontent.com/assets/5029403/5790422/01a517cc-9ea0-11e4-942c-1c06d26d10e8.png)

![screen shot 2015-01-17 at 11 55 46 pm](https://cloud.githubusercontent.com/assets/5029403/5790494/683fafb6-9ea4-11e4-9dba-7e482dbceaac.png)