### PR TITLE
osra355 setting asterisk on mandatory fields

### DIFF
--- a/app/assets/javascripts/require-star.js
+++ b/app/assets/javascripts/require-star.js
@@ -1,0 +1,3 @@
+$(document).ready(function(){
+  $("input[required]").parent().children("label").append("<span class=\"mandatory-field\">*</span>");
+});

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,3 +13,4 @@
  *= require_self
  *= require_tree .
  */
+@import "requirestar"

--- a/app/assets/stylesheets/requirestar.css
+++ b/app/assets/stylesheets/requirestar.css
@@ -1,0 +1,11 @@
+.form-group.required-group label:after {
+  content:"*";
+  color:green;
+}
+.required-field:after {
+  content:"*";
+  color:red;
+}
+.mandatory-field {
+  color: blue;
+}

--- a/app/views/hq/partners/_form.html.erb
+++ b/app/views/hq/partners/_form.html.erb
@@ -2,13 +2,13 @@
   <%= render 'shared/errors', object: f.object %>
   <div class="form-group">
     <%= f.label :name %>
-    <%= f.text_field :name, class: "form-control" %>
+    <%= f.text_field :name, class: "form-control", required: true %>
   </div>
   <div class="form-group">
-    <%= f.label :region %>
+    <%= f.label :region, class: "required-field" %>
     <%= f.text_field :region, class: "form-control" %>
   </div>
-  <div class="form-group">
+  <div class="form-group required-group">
     <%= f.label :contact_details %>
     <%= f.text_field :contact_details, class: "form-control" %>
   </div>

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,0 +1,22 @@
+class ActionView::Helpers::FormBuilder
+  alias :orig_label :label
+
+# add a '*' after the field label if the field is required
+# see http://davidsulc.com/blog/2011/05/01/self-marking-required-fields-in-rails-3/
+# Also http://blog.pothoven.net/2012/10/self-marking-required-fields-in-rails.html
+  def label(method, content_or_options = nil, options = nil, &block)
+    if content_or_options && content_or_options.class == Hash
+      options = content_or_options
+    else
+      content = content_or_options
+    end
+
+    required_mark = ''
+    required_mark = ' *'.html_safe if object.class.validators_on(method).map(&:class).include? ActiveRecord::Validations::PresenceValidator
+
+    content ||= I18n.t("activerecord.attributes.#{object.class.name.underscore}.#{method}", :default=>method.to_s.humanize)
+    content = content + required_mark
+
+    self.orig_label(method, content, options || {}, &block)
+  end
+end


### PR DESCRIPTION
Some other possibilities for setting * against mandatory fields.
1. (Partner :name field) Set attribute “require” on input field. Use javascript to add the * onto the associated label. (This has been implemented for <input> elements only and would need to be extended for other types of input controls). 
2. (Partner :region field) Set "required-field" class on the label which is associated with the mandatory input field.
3. (Partner :contact_details field) Set "required-group" on the form-group which is a parent of the mandatory input field.
Note that this has just been pushed up for comments, not for merging.