### PR TITLE
refactor partners controller to use params.require

### DIFF
--- a/app/controllers/hq/partners_controller.rb
+++ b/app/controllers/hq/partners_controller.rb
@@ -10,8 +10,8 @@ class Hq::PartnersController < ApplicationController
     @partner = Partner.new
     load_associations
   end
-  
-  def create 
+
+  def create
     build_partner
     save_partner or re_render 'new'
   end
@@ -59,13 +59,10 @@ private
   end
 
   def partner_params
-    partner_params = params[:partner]
-    if partner_params
-      partner_params.permit(:name, :region, :contact_details, :province_id,
-                            :status_id, :start_date)
-    else
-      {}
-    end
+    params.require(:partner)
+          .permit(:name, :region, :contact_details,
+                  :province_id, :status_id, :start_date)
   end
 
 end
+

--- a/spec/controllers/hq/partners_controller_spec.rb
+++ b/spec/controllers/hq/partners_controller_spec.rb
@@ -26,21 +26,21 @@ RSpec.describe Hq::PartnersController, type: :controller do
   end
 
   context '#new and #create' do
-    let(:partner_double) { instance_double Partner, :attributes= => true }
-    
+    let(:partner) { build_stubbed :partner }
+
     before :each do
-      controller.instance_variable_set(:@partner, partner_double)
+      controller.instance_variable_set(:@partner, partner)
     end
-    
+
     specify 'successful create redirects to the show view' do
-      expect(partner_double).to receive(:save).and_return(true)
-      post :create, partner: {}
-      expect(response).to redirect_to hq_partner_path(partner_double)
+      expect(partner).to receive(:save).and_return(true)
+      post :create, partner: partner.attributes
+      expect(response).to redirect_to hq_partner_path(partner)
     end
 
     specify 'unsuccessful create renders the new view' do
-      expect(partner_double).to receive(:save).and_return(false)
-      post :create, partner: {}
+      expect(partner).to receive(:save).and_return(false)
+      post :create, partner: partner.attributes
       expect(response).to render_template 'new'
     end
 
@@ -60,13 +60,13 @@ RSpec.describe Hq::PartnersController, type: :controller do
 
     specify 'unsuccessful update renders the edit view' do
       expect(@partner).to receive(:save).and_return(false)
-      patch :update, id: @partner.id
+      patch :update, id: @partner.id, partner: @partner.attributes
       expect(response).to render_template 'edit'
     end
 
     specify 'successful update redirects to the show view' do
       expect(@partner).to receive(:save).and_return(true)
-      patch :update, id: @partner.id
+      patch :update, id: @partner.id, partner: @partner.attributes
       expect(response).to redirect_to(hq_partner_path(@partner))
     end
 


### PR DESCRIPTION
Given build_partner is not used for its original intended purpose and the conversations about params.require in #282.
#partner_params has now been refactored to remove the unnecessary guards and introduce params.require in its place.