### PR TITLE
OSRA-349 sponsorship destruction

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -89,6 +89,10 @@ ActiveAdmin.register Sponsor do
             input '', type: :hidden, name: :authenticity_token, value: form_authenticity_token
           text_node '</form>'.html_safe
         end
+        column '' do |_sponsorship|
+          link_to 'X', admin_sponsor_sponsorship_path(sponsor_id: sponsor.id, id: _sponsorship.id), method: :delete,
+            data: { confirm: 'WARNING: You are about to permanently delete the record of this sponsorship!' }
+        end
       end
     end
 

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Sponsorship do
   menu if: proc { false }
-  actions :create
+  actions :create, :destroy
   belongs_to :sponsor
 
   member_action :inactivate, method: :put do

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -124,6 +124,10 @@ class Orphan < ActiveRecord::Base
     current_sponsorship.sponsor if currently_sponsored?
   end
 
+  def resolve_sponsorship_status
+    reactivate and save!
+  end
+
 private
 
   def sponsored_siblings_does_not_exceed_siblings_count

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -5,6 +5,7 @@ class Sponsorship < ActiveRecord::Base
   before_create :set_orphan_status_to_sponsored
   before_validation(on: :create) { :set_active_to_true }
   after_save :update_sponsor
+  after_destroy :update_sponsor, :update_orphan
 
   validates :sponsor, presence: true
   validates :orphan, presence: true
@@ -56,6 +57,10 @@ private
 
   def update_sponsor
     self.sponsor.sponsorship_changed!
+  end
+
+  def update_orphan
+    self.orphan.resolve_sponsorship_status
   end
 
   def set_orphan_status_to_previously_sponsored

--- a/features/aa/aa_features/sponsorship.feature
+++ b/features/aa/aa_features/sponsorship.feature
@@ -167,3 +167,9 @@ Feature:
     Given I click the "Orphans" link
     Then I should not see a Sponsors Path crumb
     And I should not see a Sponsor Path crumb
+
+  Scenario: Sponsorship destruction
+    Given I have mistakenly created a sponsorship between "Wrong Sponsor" and "Wrong Orphan"
+    And I destroy the record of the "Wrong Sponsor" - "Wrong Orphan" sponsorship
+    Then sponsorship data for "Wrong Sponsor" should reset
+    And sponsorship status for "Wrong Orphan" should reset

--- a/lib/tasks/clear_orphans.rake
+++ b/lib/tasks/clear_orphans.rake
@@ -5,7 +5,7 @@ namespace :db do
     OrphanList.destroy_all
     PendingOrphan.destroy_all
     PendingOrphanList.destroy_all
-    Sponsorship.destroy_all
+    Sponsorship.delete_all # skip callbacks on already destroyed orphan records
 
     Sponsor.update_all(:request_fulfilled => false)
 

--- a/spec/models/sponsorship_spec.rb
+++ b/spec/models/sponsorship_spec.rb
@@ -110,6 +110,20 @@ describe Sponsorship, type: :model do
         expect(sponsorship.sponsor).to have_received(:sponsorship_changed!)
       end
     end
+
+    describe 'after_destroy' do
+      let(:sponsorship) { create :sponsorship }
+
+      it 'resets sponsor' do
+        expect(sponsorship.sponsor).to receive(:sponsorship_changed!)
+        sponsorship.destroy
+      end
+
+      it 'resets orphan' do
+        expect(sponsorship.orphan).to receive(:resolve_sponsorship_status)
+        sponsorship.destroy
+      end
+    end
   end
 
   describe 'methods' do

--- a/spec/routing/admin/sponsorships_routing_spec.rb
+++ b/spec/routing/admin/sponsorships_routing_spec.rb
@@ -9,5 +9,5 @@ describe 'Sponsorships routing', type: :routing do
   specify { expect(get: '/admin/sponsors/1/sponsorships/1/edit').not_to be_routable }
   specify { expect(patch: '/admin/sponsors/1/sponsorships/1').not_to be_routable }
   specify { expect(put: '/admin/sponsors/1/sponsorships/1').not_to be_routable }
-  specify { expect(delete: '/admin/sponsors/1/sponsorships/1').not_to be_routable }
+  specify { expect(delete: '/admin/sponsors/1/sponsorships/1').to be_routable }
 end


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-349

As per client request, enable sponsorship destruction, to be used in cases of
incorrectly created sponsorships. `after_destroy` callback on the Sponsorship
model instructs pertinent Sponsor & Orphan records to update themselves. The
update functionality for Sponsor & Orphan is awkwardly repurposed from already
existing - will refactor (see below).

-----
### Original PR description

Notes:
- Sponsor "reset" upon sponsorship destruction is the exact same callback that takes place on sponsorship save
- Orphan "reset" is the same callback that takes place on orphan reactivation (status change from "On Hold" to "Active")

At the very least, in the case of Orphan I would like to unify the disjointed actions that take place on sponsorship creation, sponsorship inactivation, sponsorship destruction, and orphan reactivation into a single interface. Ideally, however, I would like to experiment with extracting a service object that handles all necessary events whenever sponsorship changes state.

Given that the functionality is now in place, but very much cobbled together out of existing pieces rather than designed with any degree of forethought or elegance, what are people's thoughts on how to proceed with the refactoring I propose (which might become substantial)? If the decision is to merge, then I will definitely proceed with the refactoring ASAP instead of leaving it for "later".