### PR TITLE
OSRA-369 Make sponsor agent mandatory

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -29,6 +29,7 @@ class Sponsor < ActiveRecord::Base
   validate :can_be_inactivated, if: :being_inactivated?, on: :update
   validates_format_of :email, with: Devise.email_regexp, allow_blank: true
   validate :type_matches_affiliation, on: :create
+  validates :agent, presence: true
 
   belongs_to :branch
   belongs_to :organization

--- a/features/aa/aa_features/sponsor.feature
+++ b/features/aa/aa_features/sponsor.feature
@@ -21,6 +21,7 @@ Feature:
       | start_date             | 2013-09-25         | 2013-09-25            | 2013-09-25          |
       | status                 | Active             | Active                | Active              |
       | payment_plan           | Every Two Months   |                       | Other               |
+      | agent                  | Agent1             | Agent2                | Agent1              |
 
     And I am a new, authenticated user
 

--- a/features/aa/step_definitions/aa_steps/sponsors_steps.rb
+++ b/features/aa/step_definitions/aa_steps/sponsors_steps.rb
@@ -2,18 +2,21 @@ Given(/^the following sponsors exist:$/) do |table|
   table = table.transpose
   table.hashes.each do |hash|
     sponsor_type = SponsorType.find_by_name(hash[:sponsor_type])
-    
+
     unless hash[:branch].blank?
       branch = Branch.find_by_name(hash[:branch]) ||
           FactoryGirl.create(:branch, name: hash[:branch])
     end
 
     unless hash[:organization].blank?
-      organization = Organization.find_by_name(hash[:organization]) 
+      organization = Organization.find_by_name(hash[:organization])
     end
-    
+
+    agent = User.find_by_user_name(hash[:agent]) ||
+      FactoryGirl.create(:agent, user_name: hash[:agent])
+
     status= Status.find_by_name(hash[:status])
-    
+
     sponsor = Sponsor.new(name: hash[:name], country: hash[:country],
                           gender: hash[:gender], sponsor_type: sponsor_type,
                           requested_orphan_count: hash[:requested_orphan_count],
@@ -22,7 +25,7 @@ Given(/^the following sponsors exist:$/) do |table|
                           additional_info: hash[:additional_info], branch: branch,
                           organization: organization, city: hash[:city],
                           start_date: hash[:start_date], status: status,
-                          payment_plan: hash[:payment_plan])
+                          payment_plan: hash[:payment_plan], agent: agent)
     sponsor.save!
   end
 end

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -16,5 +16,6 @@ FactoryGirl.define do
     branch { Branch.all.sample if sponsor_type.name == 'Individual' }
     organization { Organization.all.sample if sponsor_type.name == 'Organization' }
     payment_plan { Sponsor::PAYMENT_PLANS.sample }
+    agent
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :user do
+  factory :user, aliases: [:agent] do
     sequence(:user_name) { |n| "#{Faker::Name.name} #{n}" }
     email { Faker::Internet.email("#{user_name}") }
   end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -23,6 +23,7 @@ describe Sponsor, type: :model do
   it { is_expected.not_to allow_value(Sponsor::NEW_CITY_MENU_OPTION).for(:city).
                               with_message 'Please enter city name below. &darr;' }
   it { is_expected.to validate_presence_of :sponsor_type }
+  it { is_expected.to validate_presence_of :agent }
 
   it { is_expected.to validate_inclusion_of(:gender).in_array Settings.lookup.gender }
   it { is_expected.to validate_inclusion_of(:payment_plan).in_array (Sponsor::PAYMENT_PLANS << '') }


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-369

Assignment of agent to sponsor is now mandatory as per client request.
Only new test is in sponsor model spec.
Factories & features modified to pass.

**All sponsors currently on production have agents assigned.** I have asked the client to continue doing so for all new sponsors. Once this PR is merged, I'll add agents to all sponsors from the CLI on testing, and then will do same after pushing to staging.