### PR TITLE
Consolidate sponsorship-related actions

### DIFF
--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -124,8 +124,8 @@ class Orphan < ActiveRecord::Base
     current_sponsorship.sponsor if currently_sponsored?
   end
 
-  def resolve_sponsorship_status
-    reactivate and save!
+  def sponsorship_changed!
+    resolve_sponsorship_status and save!
   end
 
 private
@@ -168,7 +168,7 @@ private
 
   def qualify_for_sponsorship_by_status
     if orphan_status_is_active?
-      reactivate
+      resolve_sponsorship_status
     elsif orphan_status_was_active?
       deactivate
     end
@@ -186,7 +186,7 @@ private
     self.orphan_sponsorship_status = OrphanSponsorshipStatus.find_by_name 'On Hold'
   end
 
-  def reactivate
+  def resolve_sponsorship_status
     if unsponsored?
       set_sponsorship_status 'Unsponsored'
     elsif previously_sponsored?

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -368,18 +368,18 @@ describe Orphan, type: :model do
             specify 'when orphan_status is not changed' do
               expect(active_unsponsored_orphan).not_to receive(:qualify_for_sponsorship_by_status)
               expect(active_unsponsored_orphan).not_to receive(:deactivate)
-              expect(active_unsponsored_orphan).not_to receive(:reactivate)
+              expect(active_unsponsored_orphan).not_to receive(:resolve_sponsorship_status)
               active_unsponsored_orphan.update!(name: 'New Name')
             end
 
             specify 'when one disqualifying orphan_status changes to another' do
-              expect(inactive_unsponsored_orphan).not_to receive(:reactivate)
+              expect(inactive_unsponsored_orphan).not_to receive(:resolve_sponsorship_status)
               inactive_unsponsored_orphan.update!(orphan_status: on_hold_orphan_status)
 
-              expect(on_hold_sponsored_orphan).not_to receive(:reactivate)
+              expect(on_hold_sponsored_orphan).not_to receive(:resolve_sponsorship_status)
               on_hold_sponsored_orphan.update!(orphan_status: under_revision_orphan_status)
 
-              expect(under_revision_unsponsored_orphan).not_to receive(:reactivate)
+              expect(under_revision_unsponsored_orphan).not_to receive(:resolve_sponsorship_status)
               under_revision_unsponsored_orphan.update!(orphan_status: inactive_orphan_status)
             end
           end


### PR DESCRIPTION
The Sponsorship model was taking too much responsibility for managing its orphan's sponsorship status. It was also doing this in a redundant fashion. This small update removes the redundancy and hands all responsibility for determining sponsorship status to the orphan.

As an added bonus, since orphan status change upon sponsorship inactivation is now invoked within sponsorship's `after_save` callback rather than from the `inactivate` method, these two events are automatically wrapped in a db transaction and thus become atomic.

 - consolidate calls to sponsor & orphan update methods within Sponsorship `after_save` & `after_destroy`
 - implement `Orphan#sponsorship_changed!` which is called from Sponsorship `after_save` & `after_destroy`
 - rename `Orphan#reactivate` to `#resolve_sponsorship_status` to reflect its use both upon orphan reactivation and sponsorship changes
 - remove methods made redundant by the above changes
 - adjust specs accordingly