### PR TITLE
part of osra282: small fix for Partner#index controller action

### DIFF
--- a/app/controllers/hq/partners_controller.rb
+++ b/app/controllers/hq/partners_controller.rb
@@ -1,6 +1,6 @@
 class Hq::PartnersController < HqController
   def index
-    @partners = Partner.all.paginate(:page => params[:page])
+    @partners = Partner.paginate(:page => params[:page])
   end
 
   def new

--- a/spec/controllers/hq/partners_controller_spec.rb
+++ b/spec/controllers/hq/partners_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hq::PartnersController, type: :controller do
 
   describe 'index' do
     specify 'pagination' do
-      expect(Partner).to receive_message_chain(:all, :paginate).with(page: "2").and_return([].paginate)
+      expect(Partner).to receive(:paginate).with(page: "2").and_return([].paginate)
       get :index, page: "2"
     end
   end


### PR DESCRIPTION
removed `.all` from  `Partner.all.paginate(:page => params[:page])` so it is similar with Sponsors#index

Partners#index pagination:
https://osraav.atlassian.net/browse/OSRA-282
https://github.com/AgileVentures/osra/pull/307

Sponsor#index pagination:
https://osraav.atlassian.net/browse/OSRA-343
https://github.com/AgileVentures/osra/pull/312