### PR TITLE
pt.I: InactivateSponsorship service object

### DIFF
--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -4,14 +4,18 @@ ActiveAdmin.register Sponsorship do
   belongs_to :sponsor
 
   member_action :inactivate, method: :put do
-    sponsorship = Sponsorship.find(params[:id])
     sponsor = Sponsor.find(params[:sponsor_id])
-    if sponsorship.inactivate params[:end_date]
-      flash[:success] = 'Sponsorship link was successfully terminated'
-    else
-      flash[:warning] = sponsorship.errors.full_messages || 'Sponsorship not terminated'
+    sponsorship = sponsor.sponsorships.find(params[:id])
+    begin
+      InactivateSponsorship.new(sponsor: sponsor,
+                                sponsorship: sponsorship,
+                                end_date: params[:end_date]).call
+      flash[:success] = 'Sponsorship link was successfully terminated.'
+    rescue
+      flash[:warning] = 'Sponsorship link could not be terminated.'
+    ensure
+      redirect_to admin_sponsor_path(sponsor)
     end
-    redirect_to admin_sponsor_path(sponsor)
   end
 
   controller do

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -1,0 +1,43 @@
+class InactivateSponsorship
+
+  def initialize(sponsor:, sponsorship:, end_date:)
+    @sponsorship = sponsorship
+    @end_date = end_date
+    @sponsor = sponsor
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      inactivate_sponsorship!
+      update_orphan!
+      update_sponsor!
+    end
+  end
+
+  def inactivate_sponsorship!
+    @sponsorship.update!(active: false, end_date: @end_date)
+  end
+
+  def update_orphan!
+    new_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
+    @sponsorship.orphan.update!(orphan_sponsorship_status: new_status)
+  end
+
+  def update_sponsor!
+    set_request_fulfilled!
+    set_active_sponsorship_count!
+  end
+
+  def set_request_fulfilled!
+    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
+  end
+
+  def is_request_fulfilled?
+    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
+  end
+
+  def set_active_sponsorship_count!
+    @sponsor.update!(active_sponsorship_count:
+                     @sponsor.sponsorships.all_active.size)
+  end
+end


### PR DESCRIPTION
## Do not merge!

### Part I of IV - replace model callbacks handling sponsorship events with service objects.

_The main point of concern for me in undertaking this was the fact that the Sponsorship model had been made responsible for ensuring that pertinent Sponsor & Orphan objects were updated synchronously whenever the sponsorship changed (was created, destroyed or inactivated). Secondarily, though still importantly, both Sponsor & Orphan had become loaded with many methods that went well beyond the core responsibilities of an AR model, namely persistence, validations & associations._

Here, a `InactivateSponsorship` PORO class is created to handle sponsorship inactivation and attendant changes to the associated sponsor & orphan records. The sponsorships controller (AA) is modified to use this service object instead of calling sponsorship, sponsor & orphan instance methods.

Most of this code will change in parts 2-4, so focus on the approach rather than the implementation.