### PR TITLE
pt. III DestroySponsorship service object

### DIFF
--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -36,5 +36,19 @@ ActiveAdmin.register Sponsorship do
     end
   end
 
+  def destroy
+    sponsor = Sponsor.find(params[:sponsor_id])
+    sponsorship = sponsor.sponsorships.find(params[:id])
+    begin
+      DestroySponsorship.new(sponsor: sponsor,
+                                   sponsorship: sponsorship).call
+      flash[:success] = 'Sponsorship record was successfully destroyed.'
+    rescue
+      flash[:warning] = 'Sponsorship record could not be destroyed.'
+    ensure
+      redirect_to admin_sponsor_path(sponsor)
+    end
+  end
+
   permit_params :orphan_id
 end

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -4,14 +4,18 @@ ActiveAdmin.register Sponsorship do
   belongs_to :sponsor
 
   member_action :inactivate, method: :put do
-    sponsorship = Sponsorship.find(params[:id])
     sponsor = Sponsor.find(params[:sponsor_id])
-    if sponsorship.inactivate params[:end_date]
-      flash[:success] = 'Sponsorship link was successfully terminated'
-    else
-      flash[:warning] = sponsorship.errors.full_messages || 'Sponsorship not terminated'
+    sponsorship = sponsor.sponsorships.find(params[:id])
+    begin
+      InactivateSponsorship.new(sponsor: sponsor,
+                                sponsorship: sponsorship,
+                                end_date: params[:end_date]).call
+      flash[:success] = 'Sponsorship link was successfully terminated.'
+    rescue
+      flash[:warning] = 'Sponsorship link could not be terminated.'
+    ensure
+      redirect_to admin_sponsor_path(sponsor)
     end
-    redirect_to admin_sponsor_path(sponsor)
   end
 
   controller do

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -20,15 +20,18 @@ ActiveAdmin.register Sponsorship do
 
   controller do
     def create
-      @sponsor = Sponsor.find(params[:sponsor_id])
-      sponsorship= Sponsorship.new(sponsor: @sponsor, orphan_id: params[:orphan_id],
-                                      start_date: params[:sponsorship_start_date].to_s )
-      if sponsorship.save
+      sponsor = Sponsor.find(params[:sponsor_id])
+      sponsorship = sponsor.sponsorships.build(orphan_id: params[:orphan_id],
+                                               start_date: params[:sponsorship_start_date])
+      begin
+        CreateSponsorship.new(sponsor: sponsor, sponsorship: sponsorship).call
         flash[:success] = 'Sponsorship link was successfully created.'
-        redirect_to admin_sponsor_path(@sponsor.id)
-      else
-        flash[:warning]= sponsorship.errors.full_messages || 'Sponsorship not created'
-        redirect_to new_sponsorship_path(@sponsor.id, scope: 'eligible_for_sponsorship')
+        redirect_to admin_sponsor_path(sponsor)
+      rescue
+        error_msg = sponsorship.errors.full_messages ||
+          'Sponsorship link could not be created.'
+        flash[:warning] = error_msg
+        redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
       end
     end
   end

--- a/app/services/create_sponsorship.rb
+++ b/app/services/create_sponsorship.rb
@@ -1,0 +1,20 @@
+class CreateSponsorship
+
+  def initialize(sponsor:, sponsorship:)
+    @sponsor = sponsor
+    @sponsorship = sponsorship
+    @orphan = sponsorship.orphan
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      save_sponsorship!
+      UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call
+      UpdateSponsorSponsorshipData.new(@sponsor).call
+    end
+  end
+
+  def save_sponsorship!
+    @sponsorship.save!
+  end
+end

--- a/app/services/destroy_sponsorship.rb
+++ b/app/services/destroy_sponsorship.rb
@@ -1,0 +1,21 @@
+class DestroySponsorship
+
+  def initialize(sponsor:, sponsorship:)
+    @sponsor = sponsor
+    @sponsorship = sponsorship
+    @orphan = sponsorship.orphan
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      destroy_sponsorship!
+      resolve_status_and_update_orphan!
+      UpdateSponsorSponsorshipData.new(@sponsor).call
+    end
+  end
+
+  def resolve_status_and_update_orphan!
+    status = ResolveOrphanSponsorshipStatus.new(@orphan).call
+    UpdateOrphanSponsorshipStatus.new(@orphan, status).call
+  end
+end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -1,0 +1,43 @@
+class InactivateSponsorship
+
+  def initialize(sponsor:, sponsorship:, end_date:)
+    @sponsorship = sponsorship
+    @end_date = end_date
+    @sponsor = sponsor
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      inactivate_sponsorship!
+      update_orphan!
+      update_sponsor!
+    end
+  end
+
+  def inactivate_sponsorship!
+    @sponsorship.update!(active: false, end_date: @end_date)
+  end
+
+  def update_orphan!
+    new_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
+    @sponsorship.orphan.update!(orphan_sponsorship_status: new_status)
+  end
+
+  def update_sponsor!
+    set_request_fulfilled!
+    set_active_sponsorship_count!
+  end
+
+  def set_request_fulfilled!
+    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
+  end
+
+  def is_request_fulfilled?
+    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
+  end
+
+  def set_active_sponsorship_count!
+    @sponsor.update!(active_sponsorship_count:
+                     @sponsor.sponsorships.all_active.size)
+  end
+end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -4,40 +4,18 @@ class InactivateSponsorship
     @sponsorship = sponsorship
     @end_date = end_date
     @sponsor = sponsor
+    @orphan = sponsorship.orphan
   end
 
   def call
     ActiveRecord::Base.transaction do
       inactivate_sponsorship!
-      update_orphan!
-      update_sponsor!
+      UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call
+      UpdateSponsorSponsorshipData.new(@sponsor).call
     end
   end
 
   def inactivate_sponsorship!
     @sponsorship.update!(active: false, end_date: @end_date)
-  end
-
-  def update_orphan!
-    new_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
-    @sponsorship.orphan.update!(orphan_sponsorship_status: new_status)
-  end
-
-  def update_sponsor!
-    set_request_fulfilled!
-    set_active_sponsorship_count!
-  end
-
-  def set_request_fulfilled!
-    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
-  end
-
-  def is_request_fulfilled?
-    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
-  end
-
-  def set_active_sponsorship_count!
-    @sponsor.update!(active_sponsorship_count:
-                     @sponsor.sponsorships.all_active.size)
   end
 end

--- a/app/services/resolve_orphan_sponsorship_status.rb
+++ b/app/services/resolve_orphan_sponsorship_status.rb
@@ -1,0 +1,16 @@
+class ResolveOrphanSponsorshipStatus
+
+  def initialize(orphan)
+    @orphan = orphan
+  end
+
+  def call
+    if @orphan.sponsorships.empty?
+      'Unsponsored'
+    elsif @orphan.sponsorships.all_active.empty?
+      'Previously Sponsored'
+    elsif @orphan.sponsorships.all_active.present?
+      'Sponsored'
+    end
+  end
+end

--- a/app/services/update_orphan_sponsorship_status.rb
+++ b/app/services/update_orphan_sponsorship_status.rb
@@ -1,0 +1,12 @@
+class UpdateOrphanSponsorshipStatus
+
+  def initialize(orphan, status_name)
+    @orphan = orphan
+    @status_name = status_name
+  end
+
+  def call
+    status = OrphanSponsorshipStatus.find_by_name @status_name
+    @orphan.update!(orphan_sponsorship_status: status)
+  end
+end

--- a/app/services/update_sponsor_sponsorship_data.rb
+++ b/app/services/update_sponsor_sponsorship_data.rb
@@ -1,0 +1,24 @@
+class UpdateSponsorSponsorshipData
+
+  def initialize(sponsor)
+    @sponsor = sponsor
+  end
+
+  def call
+    set_request_fulfilled!
+    set_active_sponsorship_count!
+  end
+
+  def set_request_fulfilled!
+    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
+  end
+
+  def is_request_fulfilled?
+    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
+  end
+
+  def set_active_sponsorship_count!
+    @sponsor.update!(active_sponsorship_count:
+                     @sponsor.sponsorships.all_active.size)
+  end
+end


### PR DESCRIPTION
## Do not merge!

### Part III of IV - replace model callbacks handling sponsorship events with service objects.

_The main point of concern for me in undertaking this was the fact that the Sponsorship model had been made responsible for ensuring that pertinent Sponsor & Orphan objects were updated synchronously whenever the sponsorship changed (was created, destroyed or inactivated). Secondarily, though still importantly, both Sponsor & Orphan had become loaded with many methods that went well beyond the core responsibilities of an AR model, namely persistence, validations & associations._

Here, a `DestroySponsorship` service object is created following the patterns established in pts. I & II. Since upon sponsorship destruction an orphan's sponsorship status must be resolved based on its remaining sponsorship associations, a `ResolveOrphanSponsorshipStatus` service object is also created. This functionality is also used whenever an orphan is reactivated (status change from 'On Hold' or 'Inactive' to 'Active') - see pt. IV.