### PR TITLE
pt. IV Sponsorship Service Objects

### DIFF
--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -1,33 +1,9 @@
 ActiveAdmin.register Sponsorship do
   menu if: proc { false }
-  actions :create
+  actions :create, :destroy
   belongs_to :sponsor
 
   member_action :inactivate, method: :put do
-    sponsor = Sponsor.find(params[:sponsor_id])
-    sponsorship = sponsor.sponsorships.find(params[:id])
-    begin
-      InactivateSponsorship.new(sponsorship: sponsorship,
-                                end_date: params[:end_date]).call
-      flash[:success] = 'Sponsorship link was successfully terminated.'
-    rescue => error
-      flash[:warning] = error.message
-    ensure
-      redirect_to admin_sponsor_path(sponsor)
-    end
-  end
-
-  member_action :destroy, method: :delete do
-    sponsor = Sponsor.find(params[:sponsor_id])
-    sponsorship = sponsor.sponsorships.find(params[:id])
-    begin
-      DestroySponsorship.new(sponsorship).call
-      flash[:success] = 'Sponsorship record was successfully destroyed.'
-    rescue => error
-      flash[:warning] = error.message
-    ensure
-      redirect_to admin_sponsor_path(sponsor)
-    end
   end
 
   controller do
@@ -35,13 +11,60 @@ ActiveAdmin.register Sponsorship do
       sponsor = Sponsor.find(params[:sponsor_id])
       sponsorship = sponsor.sponsorships.build(orphan_id: params[:orphan_id],
                                                start_date: params[:sponsorship_start_date])
-      begin
-        CreateSponsorship.new(sponsorship).call
+
+      @sponsorship_creator = CreateSponsorship.new(sponsorship)
+
+      create_sponsorship_for(sponsor) or
+        redirect_back_to_new_sponsorship_for(sponsor)
+    end
+
+    def inactivate
+      sponsor = Sponsor.find(params[:sponsor_id])
+      sponsorship = sponsor.sponsorships.find(params[:id])
+
+      @sponsorship_inactivator = InactivateSponsorship.new(sponsorship: sponsorship,
+                                                           end_date: params[:end_date])
+
+      inactivate_sponsorship and redirect_to admin_sponsor_path(sponsor)
+    end
+
+    def destroy
+      sponsor = Sponsor.find(params[:sponsor_id])
+      sponsorship = sponsor.sponsorships.find(params[:id])
+
+      @sponsorship_destructor = DestroySponsorship.new(sponsorship)
+
+      destroy_sponsorship and
+        redirect_to admin_sponsor_path(sponsor)
+    end
+
+    private
+
+    def create_sponsorship_for(sponsor)
+      if @sponsorship_creator.call
         flash[:success] = 'Sponsorship link was successfully created.'
         redirect_to admin_sponsor_path(sponsor)
-      rescue => error
-        flash[:warning] = error.message
-        redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
+      end
+    end
+
+    def redirect_back_to_new_sponsorship_for(sponsor)
+      flash[:warning] = @sponsorship_creator.error_msg
+      redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
+    end
+
+    def inactivate_sponsorship
+      if @sponsorship_inactivator.call
+        flash[:success] = 'Sponsorship link was successfully terminated.'
+      else
+        flash[:warning] = @sponsorship_inactivator.error_msg
+      end
+    end
+
+    def destroy_sponsorship
+      if @sponsorship_destructor.call
+        flash[:success] = 'Sponsorship record was successfully destroyed.'
+      else
+        flash[:warning] = @sponsorship_destructor.error_msg
       end
     end
   end

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -10,8 +10,8 @@ ActiveAdmin.register Sponsorship do
       InactivateSponsorship.new(sponsorship: sponsorship,
                                 end_date: params[:end_date]).call
       flash[:success] = 'Sponsorship link was successfully terminated.'
-    rescue
-      flash[:warning] = 'Sponsorship link could not be terminated.'
+    rescue => error
+      flash[:warning] = error.message
     ensure
       redirect_to admin_sponsor_path(sponsor)
     end
@@ -23,8 +23,8 @@ ActiveAdmin.register Sponsorship do
     begin
       DestroySponsorship.new(sponsorship).call
       flash[:success] = 'Sponsorship record was successfully destroyed.'
-    rescue
-      flash[:warning] = 'Sponsorship record could not be destroyed.'
+    rescue => error
+      flash[:warning] = error.message
     ensure
       redirect_to admin_sponsor_path(sponsor)
     end
@@ -39,10 +39,8 @@ ActiveAdmin.register Sponsorship do
         CreateSponsorship.new(sponsorship).call
         flash[:success] = 'Sponsorship link was successfully created.'
         redirect_to admin_sponsor_path(sponsor)
-      rescue
-        error_msg = sponsorship.errors.full_messages ||
-          'Sponsorship link could not be created.'
-        flash[:warning] = error_msg
+      rescue => error
+        flash[:warning] = error.message
         redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
       end
     end

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -1,18 +1,30 @@
 ActiveAdmin.register Sponsorship do
   menu if: proc { false }
-  actions :create, :destroy
+  actions :create
   belongs_to :sponsor
 
   member_action :inactivate, method: :put do
     sponsor = Sponsor.find(params[:sponsor_id])
     sponsorship = sponsor.sponsorships.find(params[:id])
     begin
-      InactivateSponsorship.new(sponsor: sponsor,
-                                sponsorship: sponsorship,
+      InactivateSponsorship.new(sponsorship: sponsorship,
                                 end_date: params[:end_date]).call
       flash[:success] = 'Sponsorship link was successfully terminated.'
     rescue
       flash[:warning] = 'Sponsorship link could not be terminated.'
+    ensure
+      redirect_to admin_sponsor_path(sponsor)
+    end
+  end
+
+  member_action :destroy, method: :delete do
+    sponsor = Sponsor.find(params[:sponsor_id])
+    sponsorship = sponsor.sponsorships.find(params[:id])
+    begin
+      DestroySponsorship.new(sponsorship).call
+      flash[:success] = 'Sponsorship record was successfully destroyed.'
+    rescue
+      flash[:warning] = 'Sponsorship record could not be destroyed.'
     ensure
       redirect_to admin_sponsor_path(sponsor)
     end
@@ -24,7 +36,7 @@ ActiveAdmin.register Sponsorship do
       sponsorship = sponsor.sponsorships.build(orphan_id: params[:orphan_id],
                                                start_date: params[:sponsorship_start_date])
       begin
-        CreateSponsorship.new(sponsor: sponsor, sponsorship: sponsorship).call
+        CreateSponsorship.new(sponsorship).call
         flash[:success] = 'Sponsorship link was successfully created.'
         redirect_to admin_sponsor_path(sponsor)
       rescue
@@ -33,20 +45,6 @@ ActiveAdmin.register Sponsorship do
         flash[:warning] = error_msg
         redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
       end
-    end
-  end
-
-  def destroy
-    sponsor = Sponsor.find(params[:sponsor_id])
-    sponsorship = sponsor.sponsorships.find(params[:id])
-    begin
-      DestroySponsorship.new(sponsor: sponsor,
-                                   sponsorship: sponsorship).call
-      flash[:success] = 'Sponsorship record was successfully destroyed.'
-    rescue
-      flash[:warning] = 'Sponsorship record could not be destroyed.'
-    ensure
-      redirect_to admin_sponsor_path(sponsor)
     end
   end
 

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -36,5 +36,19 @@ ActiveAdmin.register Sponsorship do
     end
   end
 
+  def destroy
+    sponsor = Sponsor.find(params[:sponsor_id])
+    sponsorship = sponsor.sponsorships.find(params[:id])
+    begin
+      DestroySponsorship.new(sponsor: sponsor,
+                                   sponsorship: sponsorship).call
+      flash[:success] = 'Sponsorship record was successfully destroyed.'
+    rescue
+      flash[:warning] = 'Sponsorship record could not be destroyed.'
+    ensure
+      redirect_to admin_sponsor_path(sponsor)
+    end
+  end
+
   permit_params :orphan_id
 end

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -4,14 +4,18 @@ ActiveAdmin.register Sponsorship do
   belongs_to :sponsor
 
   member_action :inactivate, method: :put do
-    sponsorship = Sponsorship.find(params[:id])
     sponsor = Sponsor.find(params[:sponsor_id])
-    if sponsorship.inactivate params[:end_date]
-      flash[:success] = 'Sponsorship link was successfully terminated'
-    else
-      flash[:warning] = sponsorship.errors.full_messages || 'Sponsorship not terminated'
+    sponsorship = sponsor.sponsorships.find(params[:id])
+    begin
+      InactivateSponsorship.new(sponsor: sponsor,
+                                sponsorship: sponsorship,
+                                end_date: params[:end_date]).call
+      flash[:success] = 'Sponsorship link was successfully terminated.'
+    rescue
+      flash[:warning] = 'Sponsorship link could not be terminated.'
+    ensure
+      redirect_to admin_sponsor_path(sponsor)
     end
-    redirect_to admin_sponsor_path(sponsor)
   end
 
   controller do

--- a/app/admin/sponsorship.rb
+++ b/app/admin/sponsorship.rb
@@ -20,15 +20,18 @@ ActiveAdmin.register Sponsorship do
 
   controller do
     def create
-      @sponsor = Sponsor.find(params[:sponsor_id])
-      sponsorship= Sponsorship.new(sponsor: @sponsor, orphan_id: params[:orphan_id],
-                                      start_date: params[:sponsorship_start_date].to_s )
-      if sponsorship.save
+      sponsor = Sponsor.find(params[:sponsor_id])
+      sponsorship = sponsor.sponsorships.build(orphan_id: params[:orphan_id],
+                                               start_date: params[:sponsorship_start_date])
+      begin
+        CreateSponsorship.new(sponsor: sponsor, sponsorship: sponsorship).call
         flash[:success] = 'Sponsorship link was successfully created.'
-        redirect_to admin_sponsor_path(@sponsor.id)
-      else
-        flash[:warning]= sponsorship.errors.full_messages || 'Sponsorship not created'
-        redirect_to new_sponsorship_path(@sponsor.id, scope: 'eligible_for_sponsorship')
+        redirect_to admin_sponsor_path(sponsor)
+      rescue
+        error_msg = sponsorship.errors.full_messages ||
+          'Sponsorship link could not be created.'
+        flash[:warning] = error_msg
+        redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
       end
     end
   end

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -84,11 +84,6 @@ class Orphan < ActiveRecord::Base
     end
   end
 
-  def update_sponsorship_status!(status_name)
-    sponsorship_status = OrphanSponsorshipStatus.find_by_name(status_name)
-    update!(orphan_sponsorship_status: sponsorship_status)
-  end
-
   scope :active,
         -> { joins(:orphan_status).
             where(orphan_statuses: { name: 'Active' }) }
@@ -124,10 +119,6 @@ class Orphan < ActiveRecord::Base
 
   def current_sponsor
     current_sponsorship.sponsor if currently_sponsored?
-  end
-
-  def sponsorship_changed!
-    resolve_sponsorship_status and save!
   end
 
 private
@@ -176,7 +167,8 @@ private
 
   def qualify_for_sponsorship_by_status
     if orphan_status_is_active?
-      resolve_sponsorship_status
+      new_status = ResolveOrphanSponsorshipStatus.new(self).call
+      self.orphan_sponsorship_status = OrphanSponsorshipStatus.find_by_name(new_status)
     elsif orphan_status_was_active?
       deactivate
     end
@@ -192,29 +184,6 @@ private
 
   def deactivate
     self.orphan_sponsorship_status = OrphanSponsorshipStatus.find_by_name 'On Hold'
-  end
-
-  def resolve_sponsorship_status
-    if unsponsored?
-      set_sponsorship_status 'Unsponsored'
-    elsif previously_sponsored?
-      set_sponsorship_status 'Previously Sponsored'
-    elsif currently_sponsored?
-      set_sponsorship_status 'Sponsored'
-    end
-  end
-
-  def unsponsored?
-    self.sponsorships.empty?
-  end
-
-  def previously_sponsored?
-    self.sponsorships.all_active.empty?
-  end
-
-  def set_sponsorship_status(status_name)
-    sponsorship_status = OrphanSponsorshipStatus.find_by_name(status_name)
-    self.orphan_sponsorship_status = sponsorship_status
   end
 
   def can_be_inactivated

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -13,7 +13,7 @@ class Sponsor < ActiveRecord::Base
                    :default_start_date_to_today,
                    :default_type_to_individual
   before_create :generate_osra_num, :set_request_unfulfilled
-  before_update :set_request_fulfilled
+  before_update :set_request_fulfilled, if: 'requested_orphan_count_changed?'
   before_validation :set_city
 
   validates :name, presence: true
@@ -52,20 +52,6 @@ class Sponsor < ActiveRecord::Base
 
   def eligible_for_sponsorship?
     self.status.active? && !self.request_fulfilled?
-  end
-
-  def sponsorship_changed!
-    update_request_fulfilled!
-    update_active_sponsorship_count!
-  end
-
-  def update_request_fulfilled!
-    update!(request_fulfilled: request_is_fulfilled?)
-  end
-
-  def update_active_sponsorship_count!
-    number_of_active_sponsorships = sponsorships.all_active.count
-    update!(active_sponsorship_count: number_of_active_sponsorships)
   end
 
   def currently_sponsored_orphans
@@ -130,8 +116,7 @@ class Sponsor < ActiveRecord::Base
   end
 
   def set_request_fulfilled
-    self.request_fulfilled = request_is_fulfilled?
-    true
+    UpdateSponsorSponsorshipData.new(self).call
   end
 
   def can_be_inactivated
@@ -142,10 +127,6 @@ class Sponsor < ActiveRecord::Base
 
   def being_inactivated?
     status_id_changed? && (Status.find(status_id).name == 'Inactive')
-  end
-
-  def request_is_fulfilled?
-    sponsorships.all_active.count >= requested_orphan_count
   end
 
   def type_matches_affiliation

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -24,10 +24,6 @@ class Sponsorship < ActiveRecord::Base
   delegate :name, :additional_info, :id, to: :sponsor, prefix: true
   delegate :date_of_birth, :gender, to: :orphan, prefix: true
 
-  def inactivate(end_date)
-    update_attributes(active: false, end_date: end_date)
-  end
-
   scope :all_active, -> { where(active: true) }
   scope :all_inactive, -> { where(active: false) }
 

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -3,8 +3,6 @@ class Sponsorship < ActiveRecord::Base
   include Initializer
 
   before_validation(on: :create) { :set_active_to_true }
-  after_save :update_sponsor_and_orphan
-  after_destroy :update_sponsor_and_orphan
 
   validates :sponsor, presence: true
   validates :orphan, presence: true
@@ -46,11 +44,6 @@ private
     unless end_date >= start_date
       errors[:end_date] << "can't be before the starting date (#{self.start_date})"
     end
-  end
-
-  def update_sponsor_and_orphan
-    self.sponsor.sponsorship_changed!
-    self.orphan.sponsorship_changed!
   end
 
   def set_active_to_true

--- a/app/services/create_sponsorship.rb
+++ b/app/services/create_sponsorship.rb
@@ -8,13 +8,23 @@ class CreateSponsorship
 
   def call
     ActiveRecord::Base.transaction do
-      save_sponsorship! and
-        UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call and
-        UpdateSponsorSponsorshipData.new(@sponsor).call
+      persist_sponsorship!
+      update_and_save_orphan!
+      update_and_save_sponsor!
     end
   end
 
-  def save_sponsorship!
+  def persist_sponsorship!
     @sponsorship.save!
+  end
+
+  def update_and_save_orphan!
+    UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call
+    @orphan.save!
+  end
+
+  def update_and_save_sponsor!
+    UpdateSponsorSponsorshipData.new(@sponsor).call
+    @sponsor.save!
   end
 end

--- a/app/services/create_sponsorship.rb
+++ b/app/services/create_sponsorship.rb
@@ -1,0 +1,20 @@
+class CreateSponsorship
+
+  def initialize(sponsor:, sponsorship:)
+    @sponsor = sponsor
+    @sponsorship = sponsorship
+    @orphan = sponsorship.orphan
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      save_sponsorship!
+      UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call
+      UpdateSponsorSponsorshipData.new(@sponsor).call
+    end
+  end
+
+  def save_sponsorship!
+    @sponsorship.save!
+  end
+end

--- a/app/services/create_sponsorship.rb
+++ b/app/services/create_sponsorship.rb
@@ -1,5 +1,7 @@
 class CreateSponsorship
 
+  attr_reader :error_msg
+
   def initialize(sponsorship)
     @sponsorship = sponsorship
     @sponsor = sponsorship.sponsor
@@ -7,16 +9,22 @@ class CreateSponsorship
   end
 
   def call
-    ActiveRecord::Base.transaction do
-      persist_sponsorship!
-      update_and_save_orphan!
-      update_and_save_sponsor!
+    begin
+      ActiveRecord::Base.transaction do
+        persist_sponsorship!
+        update_and_save_orphan!
+        update_and_save_sponsor!
+      end
+    rescue => error
+      self.error_msg = error.message
+      false
     end
   end
 
   private
 
   attr_reader :sponsorship, :sponsor, :orphan
+  attr_writer :error_msg
 
   def persist_sponsorship!
     sponsorship.save!

--- a/app/services/create_sponsorship.rb
+++ b/app/services/create_sponsorship.rb
@@ -1,16 +1,16 @@
 class CreateSponsorship
 
-  def initialize(sponsor:, sponsorship:)
-    @sponsor = sponsor
+  def initialize(sponsorship)
     @sponsorship = sponsorship
+    @sponsor = sponsorship.sponsor
     @orphan = sponsorship.orphan
   end
 
   def call
     ActiveRecord::Base.transaction do
-      save_sponsorship!
-      UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call
-      UpdateSponsorSponsorshipData.new(@sponsor).call
+      save_sponsorship! and
+        UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call and
+        UpdateSponsorSponsorshipData.new(@sponsor).call
     end
   end
 

--- a/app/services/create_sponsorship.rb
+++ b/app/services/create_sponsorship.rb
@@ -14,17 +14,21 @@ class CreateSponsorship
     end
   end
 
+  private
+
+  attr_reader :sponsorship, :sponsor, :orphan
+
   def persist_sponsorship!
-    @sponsorship.save!
+    sponsorship.save!
   end
 
   def update_and_save_orphan!
-    UpdateOrphanSponsorshipStatus.new(@orphan, 'Sponsored').call
-    @orphan.save!
+    UpdateOrphanSponsorshipStatus.new(orphan, 'Sponsored').call
+    orphan.save!
   end
 
   def update_and_save_sponsor!
-    UpdateSponsorSponsorshipData.new(@sponsor).call
-    @sponsor.save!
+    UpdateSponsorSponsorshipData.new(sponsor).call
+    sponsor.save!
   end
 end

--- a/app/services/destroy_sponsorship.rb
+++ b/app/services/destroy_sponsorship.rb
@@ -14,18 +14,22 @@ class DestroySponsorship
     end
   end
 
+  private
+
+  attr_reader :sponsorship, :sponsor, :orphan
+
   def destroy_sponsorship!
-    @sponsorship.destroy!
+    sponsorship.destroy!
   end
 
   def resolve_status_and_update_orphan!
-    status = ResolveOrphanSponsorshipStatus.new(@orphan).call
-    UpdateOrphanSponsorshipStatus.new(@orphan, status).call
-    @orphan.save!
+    status = ResolveOrphanSponsorshipStatus.new(orphan).call
+    UpdateOrphanSponsorshipStatus.new(orphan, status).call
+    orphan.save!
   end
 
   def update_and_save_sponsor!
-    UpdateSponsorSponsorshipData.new(@sponsor).call
-    @sponsor.save!
+    UpdateSponsorSponsorshipData.new(sponsor).call
+    sponsor.save!
   end
 end

--- a/app/services/destroy_sponsorship.rb
+++ b/app/services/destroy_sponsorship.rb
@@ -1,5 +1,7 @@
 class DestroySponsorship
 
+  attr_reader :error_msg
+
   def initialize(sponsorship)
     @sponsorship = sponsorship
     @sponsor = sponsorship.sponsor
@@ -7,16 +9,22 @@ class DestroySponsorship
   end
 
   def call
-    ActiveRecord::Base.transaction do
-      destroy_sponsorship!
-      resolve_status_and_update_orphan!
-      update_and_save_sponsor!
+    begin
+      ActiveRecord::Base.transaction do
+        destroy_sponsorship!
+        resolve_status_and_update_orphan!
+        update_and_save_sponsor!
+      end
+    rescue => error
+      self.error_msg = error.message
+      false
     end
   end
 
   private
 
   attr_reader :sponsorship, :sponsor, :orphan
+  attr_writer :error_msg
 
   def destroy_sponsorship!
     sponsorship.destroy!

--- a/app/services/destroy_sponsorship.rb
+++ b/app/services/destroy_sponsorship.rb
@@ -1,17 +1,21 @@
 class DestroySponsorship
 
-  def initialize(sponsor:, sponsorship:)
-    @sponsor = sponsor
+  def initialize(sponsorship)
     @sponsorship = sponsorship
+    @sponsor = sponsorship.sponsor
     @orphan = sponsorship.orphan
   end
 
   def call
     ActiveRecord::Base.transaction do
-      destroy_sponsorship!
-      resolve_status_and_update_orphan!
-      UpdateSponsorSponsorshipData.new(@sponsor).call
+      destroy_sponsorship! and
+        resolve_status_and_update_orphan! and
+        UpdateSponsorSponsorshipData.new(@sponsor).call
     end
+  end
+
+  def destroy_sponsorship!
+    @sponsorship.destroy!
   end
 
   def resolve_status_and_update_orphan!

--- a/app/services/destroy_sponsorship.rb
+++ b/app/services/destroy_sponsorship.rb
@@ -1,0 +1,21 @@
+class DestroySponsorship
+
+  def initialize(sponsor:, sponsorship:)
+    @sponsor = sponsor
+    @sponsorship = sponsorship
+    @orphan = sponsorship.orphan
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      destroy_sponsorship!
+      resolve_status_and_update_orphan!
+      UpdateSponsorSponsorshipData.new(@sponsor).call
+    end
+  end
+
+  def resolve_status_and_update_orphan!
+    status = ResolveOrphanSponsorshipStatus.new(@orphan).call
+    UpdateOrphanSponsorshipStatus.new(@orphan, status).call
+  end
+end

--- a/app/services/destroy_sponsorship.rb
+++ b/app/services/destroy_sponsorship.rb
@@ -8,9 +8,9 @@ class DestroySponsorship
 
   def call
     ActiveRecord::Base.transaction do
-      destroy_sponsorship! and
-        resolve_status_and_update_orphan! and
-        UpdateSponsorSponsorshipData.new(@sponsor).call
+      destroy_sponsorship!
+      resolve_status_and_update_orphan!
+      update_and_save_sponsor!
     end
   end
 
@@ -21,5 +21,11 @@ class DestroySponsorship
   def resolve_status_and_update_orphan!
     status = ResolveOrphanSponsorshipStatus.new(@orphan).call
     UpdateOrphanSponsorshipStatus.new(@orphan, status).call
+    @orphan.save!
+  end
+
+  def update_and_save_sponsor!
+    UpdateSponsorSponsorshipData.new(@sponsor).call
+    @sponsor.save!
   end
 end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -1,0 +1,43 @@
+class InactivateSponsorship
+
+  def initialize(sponsor:, sponsorship:, end_date:)
+    @sponsorship = sponsorship
+    @end_date = end_date
+    @sponsor = sponsor
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      inactivate_sponsorship!
+      update_orphan!
+      update_sponsor!
+    end
+  end
+
+  def inactivate_sponsorship!
+    @sponsorship.update!(active: false, end_date: @end_date)
+  end
+
+  def update_orphan!
+    new_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
+    @sponsorship.orphan.update!(orphan_sponsorship_status: new_status)
+  end
+
+  def update_sponsor!
+    set_request_fulfilled!
+    set_active_sponsorship_count!
+  end
+
+  def set_request_fulfilled!
+    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
+  end
+
+  def is_request_fulfilled?
+    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
+  end
+
+  def set_active_sponsorship_count!
+    @sponsor.update!(active_sponsorship_count:
+                     @sponsor.sponsorships.all_active.size)
+  end
+end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -9,13 +9,23 @@ class InactivateSponsorship
 
   def call
     ActiveRecord::Base.transaction do
-      inactivate_sponsorship! and
-        UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call and
-        UpdateSponsorSponsorshipData.new(@sponsor).call
+      inactivate_sponsorship!
+      update_and_save_orphan!
+      update_and_save_sponsor!
     end
   end
 
   def inactivate_sponsorship!
     @sponsorship.update!(active: false, end_date: @end_date)
+  end
+
+  def update_and_save_orphan!
+    UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call
+    @orphan.save!
+  end
+
+  def update_and_save_sponsor!
+    UpdateSponsorSponsorshipData.new(@sponsor).call
+    @sponsor.save!
   end
 end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -1,5 +1,7 @@
 class InactivateSponsorship
 
+  attr_reader :error_msg
+
   def initialize(sponsorship:, end_date:)
     @sponsorship = sponsorship
     @end_date = end_date
@@ -8,16 +10,22 @@ class InactivateSponsorship
   end
 
   def call
-    ActiveRecord::Base.transaction do
-      inactivate_sponsorship!
-      update_and_save_orphan!
-      update_and_save_sponsor!
+    begin
+      ActiveRecord::Base.transaction do
+        inactivate_sponsorship!
+        update_and_save_orphan!
+        update_and_save_sponsor!
+      end
+    rescue => error
+      self.error_msg = error.message
+      false
     end
   end
 
   private
 
   attr_reader :sponsorship, :end_date, :sponsor, :orphan
+  attr_writer :error_msg
 
   def inactivate_sponsorship!
     sponsorship.update!(active: false, end_date: end_date)

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -4,40 +4,18 @@ class InactivateSponsorship
     @sponsorship = sponsorship
     @end_date = end_date
     @sponsor = sponsor
+    @orphan = sponsorship.orphan
   end
 
   def call
     ActiveRecord::Base.transaction do
       inactivate_sponsorship!
-      update_orphan!
-      update_sponsor!
+      UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call
+      UpdateSponsorSponsorshipData.new(@sponsor).call
     end
   end
 
   def inactivate_sponsorship!
     @sponsorship.update!(active: false, end_date: @end_date)
-  end
-
-  def update_orphan!
-    new_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
-    @sponsorship.orphan.update!(orphan_sponsorship_status: new_status)
-  end
-
-  def update_sponsor!
-    set_request_fulfilled!
-    set_active_sponsorship_count!
-  end
-
-  def set_request_fulfilled!
-    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
-  end
-
-  def is_request_fulfilled?
-    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
-  end
-
-  def set_active_sponsorship_count!
-    @sponsor.update!(active_sponsorship_count:
-                     @sponsor.sponsorships.all_active.size)
   end
 end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -15,17 +15,21 @@ class InactivateSponsorship
     end
   end
 
+  private
+
+  attr_reader :sponsorship, :end_date, :sponsor, :orphan
+
   def inactivate_sponsorship!
-    @sponsorship.update!(active: false, end_date: @end_date)
+    sponsorship.update!(active: false, end_date: end_date)
   end
 
   def update_and_save_orphan!
-    UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call
-    @orphan.save!
+    UpdateOrphanSponsorshipStatus.new(orphan, 'Previously Sponsored').call
+    orphan.save!
   end
 
   def update_and_save_sponsor!
-    UpdateSponsorSponsorshipData.new(@sponsor).call
-    @sponsor.save!
+    UpdateSponsorSponsorshipData.new(sponsor).call
+    sponsor.save!
   end
 end

--- a/app/services/inactivate_sponsorship.rb
+++ b/app/services/inactivate_sponsorship.rb
@@ -1,17 +1,17 @@
 class InactivateSponsorship
 
-  def initialize(sponsor:, sponsorship:, end_date:)
+  def initialize(sponsorship:, end_date:)
     @sponsorship = sponsorship
     @end_date = end_date
-    @sponsor = sponsor
+    @sponsor = sponsorship.sponsor
     @orphan = sponsorship.orphan
   end
 
   def call
     ActiveRecord::Base.transaction do
-      inactivate_sponsorship!
-      UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call
-      UpdateSponsorSponsorshipData.new(@sponsor).call
+      inactivate_sponsorship! and
+        UpdateOrphanSponsorshipStatus.new(@orphan, 'Previously Sponsored').call and
+        UpdateSponsorSponsorshipData.new(@sponsor).call
     end
   end
 

--- a/app/services/resolve_orphan_sponsorship_status.rb
+++ b/app/services/resolve_orphan_sponsorship_status.rb
@@ -1,0 +1,16 @@
+class ResolveOrphanSponsorshipStatus
+
+  def initialize(orphan)
+    @orphan = orphan
+  end
+
+  def call
+    if @orphan.sponsorships.empty?
+      'Unsponsored'
+    elsif @orphan.sponsorships.all_active.empty?
+      'Previously Sponsored'
+    elsif @orphan.sponsorships.all_active.present?
+      'Sponsored'
+    end
+  end
+end

--- a/app/services/resolve_orphan_sponsorship_status.rb
+++ b/app/services/resolve_orphan_sponsorship_status.rb
@@ -5,12 +5,16 @@ class ResolveOrphanSponsorshipStatus
   end
 
   def call
-    if @orphan.sponsorships.empty?
+    if orphan.sponsorships.empty?
       'Unsponsored'
-    elsif @orphan.sponsorships.all_active.empty?
+    elsif orphan.sponsorships.all_active.empty?
       'Previously Sponsored'
-    elsif @orphan.sponsorships.all_active.present?
+    elsif orphan.sponsorships.all_active.present?
       'Sponsored'
     end
   end
+
+  private
+
+  attr_reader :orphan
 end

--- a/app/services/update_orphan_sponsorship_status.rb
+++ b/app/services/update_orphan_sponsorship_status.rb
@@ -1,0 +1,12 @@
+class UpdateOrphanSponsorshipStatus
+
+  def initialize(orphan, status_name)
+    @orphan = orphan
+    @status_name = status_name
+  end
+
+  def call
+    status = OrphanSponsorshipStatus.find_by_name @status_name
+    @orphan.update!(orphan_sponsorship_status: status)
+  end
+end

--- a/app/services/update_orphan_sponsorship_status.rb
+++ b/app/services/update_orphan_sponsorship_status.rb
@@ -6,7 +6,11 @@ class UpdateOrphanSponsorshipStatus
   end
 
   def call
-    status = OrphanSponsorshipStatus.find_by_name @status_name
-    @orphan.orphan_sponsorship_status = status
+    status = OrphanSponsorshipStatus.find_by_name status_name
+    orphan.orphan_sponsorship_status = status
   end
+
+  private
+
+  attr_reader :orphan, :status_name
 end

--- a/app/services/update_orphan_sponsorship_status.rb
+++ b/app/services/update_orphan_sponsorship_status.rb
@@ -7,6 +7,6 @@ class UpdateOrphanSponsorshipStatus
 
   def call
     status = OrphanSponsorshipStatus.find_by_name @status_name
-    @orphan.update!(orphan_sponsorship_status: status)
+    @orphan.orphan_sponsorship_status = status
   end
 end

--- a/app/services/update_sponsor_sponsorship_data.rb
+++ b/app/services/update_sponsor_sponsorship_data.rb
@@ -9,15 +9,19 @@ class UpdateSponsorSponsorshipData
     set_active_sponsorship_count
   end
 
+  private
+
+  attr_reader :sponsor
+
   def set_request_fulfilled
-    @sponsor.request_fulfilled = is_request_fulfilled?
+    sponsor.request_fulfilled = is_request_fulfilled?
   end
 
   def is_request_fulfilled?
-    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
+    sponsor.sponsorships.all_active.size >= sponsor.requested_orphan_count
   end
 
   def set_active_sponsorship_count
-    @sponsor.active_sponsorship_count = @sponsor.sponsorships.all_active.size
+    sponsor.active_sponsorship_count = sponsor.sponsorships.all_active.size
   end
 end

--- a/app/services/update_sponsor_sponsorship_data.rb
+++ b/app/services/update_sponsor_sponsorship_data.rb
@@ -5,20 +5,19 @@ class UpdateSponsorSponsorshipData
   end
 
   def call
-    set_request_fulfilled!
-    set_active_sponsorship_count!
+    set_request_fulfilled
+    set_active_sponsorship_count
   end
 
-  def set_request_fulfilled!
-    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
+  def set_request_fulfilled
+    @sponsor.request_fulfilled = is_request_fulfilled?
   end
 
   def is_request_fulfilled?
     @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
   end
 
-  def set_active_sponsorship_count!
-    @sponsor.update!(active_sponsorship_count:
-                     @sponsor.sponsorships.all_active.size)
+  def set_active_sponsorship_count
+    @sponsor.active_sponsorship_count = @sponsor.sponsorships.all_active.size
   end
 end

--- a/app/services/update_sponsor_sponsorship_data.rb
+++ b/app/services/update_sponsor_sponsorship_data.rb
@@ -1,0 +1,24 @@
+class UpdateSponsorSponsorshipData
+
+  def initialize(sponsor)
+    @sponsor = sponsor
+  end
+
+  def call
+    set_request_fulfilled!
+    set_active_sponsorship_count!
+  end
+
+  def set_request_fulfilled!
+    @sponsor.update!(request_fulfilled: is_request_fulfilled?)
+  end
+
+  def is_request_fulfilled?
+    @sponsor.sponsorships.all_active.size >= @sponsor.requested_orphan_count
+  end
+
+  def set_active_sponsorship_count!
+    @sponsor.update!(active_sponsorship_count:
+                     @sponsor.sponsorships.all_active.size)
+  end
+end

--- a/features/aa/step_definitions/aa_steps/sponsorship_steps.rb
+++ b/features/aa/step_definitions/aa_steps/sponsorship_steps.rb
@@ -14,17 +14,22 @@ end
 Given(/^an (in)?active sponsorship link exists between sponsor "([^"]*)" and orphan "([^"]*)"$/) do |inactive, sponsor_name, orphan_name|
   sponsor = Sponsor.find_by_name(sponsor_name) || FactoryGirl.create(:sponsor, name: sponsor_name)
   orphan = Orphan.find_by_name(orphan_name) || FactoryGirl.create(:orphan, name: orphan_name)
-  sponsorship = sponsor.sponsorships.create!(orphan_id: orphan.id, start_date: Date.current)
+
+  sponsorship = FactoryGirl.build :sponsorship, sponsor: sponsor, orphan: orphan
+  CreateSponsorship.new(sponsorship).call
+
   if inactive
     future_date = sponsorship.start_date + 2.months
-    sponsorship.inactivate future_date
+    InactivateSponsorship.new(sponsorship: sponsorship, end_date: future_date).call
   end
 end
 
 Given (/^"([^"]*)" started a sponsorship for "([^"]*)" on "([^"]*)"$/) do |sponsor_name, orphan_name, start_date|
   sponsor = Sponsor.find_by_name(sponsor_name) || FactoryGirl.create(:sponsor, name: sponsor_name)
   orphan = Orphan.find_by_name(orphan_name) || FactoryGirl.create(:orphan, name: orphan_name)
-  sponsorship = sponsor.sponsorships.create!(orphan_id: orphan.id, start_date: start_date)
+
+  sponsorship = FactoryGirl.build :sponsorship, sponsor: sponsor, orphan: orphan, start_date: start_date
+  CreateSponsorship.new(sponsorship).call
 end
 
 When(/I click the "Sponsor this orphan" link for orphan "([^"]*)"/) do |orphan_name|

--- a/spec/controllers/admin/sponsorships_controller_spec.rb
+++ b/spec/controllers/admin/sponsorships_controller_spec.rb
@@ -11,17 +11,21 @@ describe Admin::SponsorshipsController, type: :controller do
     allow(Sponsor).to receive(:find).with('1').and_return sponsor
   end
 
-  describe 'inactivate' do
+  describe '#inactivate' do
+
+    let(:sponsorship_inactivator) { instance_double InactivateSponsorship }
 
     before(:each) do
       expect(sponsor).to receive_message_chain(:sponsorships, :find)
+      allow(InactivateSponsorship).to receive(:new).
+        and_return sponsorship_inactivator
     end
 
     context 'when successful' do
 
       before(:each) do
-        expect(InactivateSponsorship).to receive_message_chain(:new, :call).
-          and_return true
+        expect(sponsorship_inactivator).to receive(:call).and_return true
+
         put :inactivate, { id: 1, sponsor_id: 1, end_date: '1-1-2017' }
       end
 
@@ -38,14 +42,15 @@ describe Admin::SponsorshipsController, type: :controller do
     context 'when unsuccessful' do
 
       before(:each) do
-        expect(InactivateSponsorship).to receive_message_chain(:new, :call).
-          and_raise('BOOM')
+        expect(sponsorship_inactivator).to receive(:call).and_return false
+        expect(sponsorship_inactivator).to receive(:error_msg).and_return 'No go'
+
         put :inactivate, { id: 1, sponsor_id: 1, end_date: '1-1-2017' }
       end
 
       it 'sets flash[:warning] message' do
         expect(flash[:success]).to be_nil
-        expect(flash[:warning]).to eq 'BOOM'
+        expect(flash[:warning]).to eq 'No go'
       end
 
       it 'redirects to sponsor show view' do
@@ -54,22 +59,26 @@ describe Admin::SponsorshipsController, type: :controller do
     end
   end
 
-  describe 'destroy' do
+  describe '#destroy' do
+
+    let(:sponsorship_destructor) { instance_double DestroySponsorship }
 
     before(:each) do
       allow(sponsor).to receive_message_chain(:sponsorships, :find)
+      allow(DestroySponsorship).to receive(:new).
+        and_return(sponsorship_destructor)
     end
 
     context 'when successful' do
 
       before(:each) do
-        expect(DestroySponsorship).to receive_message_chain(:new, :call).
-          and_return true
+        expect(sponsorship_destructor).to receive(:call).and_return true
+
         delete :destroy, { id: 1, sponsor_id: 1 }
       end
 
       it 'sets flash[:success] message' do
-        expect(flash[:success]).not_to be_nil
+        expect(flash[:success]).to eq 'Sponsorship record was successfully destroyed.'
         expect(flash[:warning]).to be_nil
       end
 
@@ -81,14 +90,15 @@ describe Admin::SponsorshipsController, type: :controller do
     context 'when unsuccessful' do
 
       before(:each) do
-        expect(DestroySponsorship).to receive_message_chain(:new, :call).
-          and_raise('BOOM')
+        expect(sponsorship_destructor).to receive(:call).and_return false
+        expect(sponsorship_destructor).to receive(:error_msg).and_return 'No go'
+
         delete :destroy, { id: 1, sponsor_id: 1 }
       end
 
       it 'sets flash[:warning] message' do
         expect(flash[:success]).to be_nil
-        expect(flash[:warning]).to eq 'BOOM'
+        expect(flash[:warning]).to eq 'No go'
       end
 
       it 'redirects to sponsor show view' do
@@ -97,18 +107,21 @@ describe Admin::SponsorshipsController, type: :controller do
     end
   end
 
-  describe 'create' do
+  describe '#create' do
+
+    let(:sponsorship_creator) { instance_double CreateSponsorship }
 
     before :each do
       allow(sponsor).to receive_message_chain(:sponsorships, :build)
+      allow(CreateSponsorship).to receive(:new).and_return(sponsorship_creator)
     end
 
     context 'when successful' do
 
       before(:each) do
-        expect(CreateSponsorship).to receive_message_chain(:new, :call).
-          and_return true
-        post :create, { id: 1, sponsor_id: 1, start_date: '1-1-2000' }
+        expect(sponsorship_creator).to receive(:call).and_return true
+
+        post :create, { id: 1, sponsor_id: 1, start_date: '1-1-2013' }
       end
 
       it 'sets flash[:success] message' do
@@ -122,16 +135,16 @@ describe Admin::SponsorshipsController, type: :controller do
     end
 
     context 'when unsuccessful' do
-
       before(:each) do
-        expect(CreateSponsorship).to receive_message_chain(:new, :call).
-          and_raise('BOOM')
-        post :create, { id: 1, sponsor_id: 1, start_date: '1-1-2000' }
+        expect(sponsorship_creator).to receive(:call).and_return false
+        expect(sponsorship_creator).to receive(:error_msg).and_return 'No go'
+
+        post :create, { id: 1, sponsor_id: 1, start_date: '1-1-2013' }
       end
 
       it 'sets flash[:warning] message' do
         expect(flash[:success]).to be_nil
-        expect(flash[:warning]).to eq 'BOOM'
+        expect(flash[:warning]).to eq 'No go'
       end
 
       it 'redirects to new sponsorship view' do

--- a/spec/controllers/admin/sponsorships_controller_spec.rb
+++ b/spec/controllers/admin/sponsorships_controller_spec.rb
@@ -3,30 +3,31 @@ include Devise::TestHelpers
 
 describe Admin::SponsorshipsController, type: :controller do
 
-  let(:orphan) { instance_double Orphan }
   let(:sponsor) { instance_double Sponsor }
-  let(:sponsorship) { instance_double Sponsorship, sponsor: sponsor, orphan: orphan }
+  let(:sponsorship) { instance_double Sponsorship }
 
   before(:each) do
     sign_in instance_double(AdminUser)
-    allow(sponsor).to receive(:id).and_return(1)
-    allow(Sponsor).to receive(:find).with('1').and_return(sponsor)
-    allow(Sponsorship).to receive(:find).with('1').and_return(sponsorship)
+    allow(Sponsor).to receive(:find).with('1').and_return sponsor
   end
 
   describe 'inactivate' do
-    describe 'is successful' do
-      before(:each) do
-        allow(sponsorship).to receive(:inactivate).and_return(sponsorship)
-        put :inactivate, { id: 1, sponsor_id: 1, end_date: "1-1-2017" }
-      end  
 
-      it 'calls #inactivate on sponsorship' do
-        expect(sponsorship).to have_received :inactivate
+    before(:each) do
+      expect(sponsor).to receive_message_chain(:sponsorships, :find)
+    end
+
+    context 'when successful' do
+
+      before(:each) do
+        expect(InactivateSponsorship).to receive_message_chain(:new, :call).
+          and_return true
+        put :inactivate, { id: 1, sponsor_id: 1, end_date: '1-1-2017' }
       end
 
       it 'sets flash[:success] message' do
-        expect(flash[:success]).to eq 'Sponsorship link was successfully terminated'
+        expect(flash[:success]).not_to be_nil
+        expect(flash[:warning]).to be_nil
       end
 
       it 'redirects to sponsor show view' do
@@ -34,39 +35,108 @@ describe Admin::SponsorshipsController, type: :controller do
       end
     end
 
-    describe 'is unsuccessful' do
+    context 'when unsuccessful' do
+
       before(:each) do
-        allow(sponsorship).to receive(:inactivate).and_return(false)
-        allow(sponsorship).to receive_message_chain(:errors, :full_messages).and_return("Something wrong")
-        put :inactivate, { id: 1, sponsor_id: 1, end_date: "1-1-2010" }
-      end  
+        expect(InactivateSponsorship).to receive_message_chain(:new, :call).
+          and_raise('BOOM')
+        put :inactivate, { id: 1, sponsor_id: 1, end_date: '1-1-2017' }
+      end
 
       it 'sets flash[:warning] message' do
-        expect(flash[:warning]).to eq 'Something wrong'
+        expect(flash[:success]).to be_nil
+        expect(flash[:warning]).to eq 'BOOM'
+      end
+
+      it 'redirects to sponsor show view' do
+        expect(response).to redirect_to admin_sponsor_path(sponsor)
+      end
+    end
+  end
+
+  describe 'destroy' do
+
+    before(:each) do
+      allow(sponsor).to receive_message_chain(:sponsorships, :find)
+    end
+
+    context 'when successful' do
+
+      before(:each) do
+        expect(DestroySponsorship).to receive_message_chain(:new, :call).
+          and_return true
+        delete :destroy, { id: 1, sponsor_id: 1 }
+      end
+
+      it 'sets flash[:success] message' do
+        expect(flash[:success]).not_to be_nil
+        expect(flash[:warning]).to be_nil
+      end
+
+      it 'redirects to sponsor show view' do
+        expect(response).to redirect_to admin_sponsor_path(sponsor)
+      end
+    end
+
+    context 'when unsuccessful' do
+
+      before(:each) do
+        expect(DestroySponsorship).to receive_message_chain(:new, :call).
+          and_raise('BOOM')
+        delete :destroy, { id: 1, sponsor_id: 1 }
+      end
+
+      it 'sets flash[:warning] message' do
+        expect(flash[:success]).to be_nil
+        expect(flash[:warning]).to eq 'BOOM'
+      end
+
+      it 'redirects to sponsor show view' do
+        expect(response).to redirect_to admin_sponsor_path(sponsor)
       end
     end
   end
 
   describe 'create' do
+
     before :each do
-      allow(Sponsorship).to receive(:new).and_return(sponsorship)
+      allow(sponsor).to receive_message_chain(:sponsorships, :build)
     end
 
-    it 'is successful' do
-      allow(sponsorship).to receive(:save).and_return(true)
-      post :create, { orphan_id: 1, sponsor_id: 1, sponsorship_start_date: '2002-02-02' }
-      expect(flash[:warning]).to be_nil
-      expect(flash[:success]).to eq 'Sponsorship link was successfully created.'
-      expect(response).to redirect_to admin_sponsor_path(sponsor.id)
+    context 'when successful' do
+
+      before(:each) do
+        expect(CreateSponsorship).to receive_message_chain(:new, :call).
+          and_return true
+        post :create, { id: 1, sponsor_id: 1, start_date: '1-1-2000' }
+      end
+
+      it 'sets flash[:success] message' do
+        expect(flash[:success]).not_to be_nil
+        expect(flash[:warning]).to be_nil
+      end
+
+      it 'redirects to sponsor show view' do
+        expect(response).to redirect_to admin_sponsor_path(sponsor)
+      end
     end
 
-    it 'is unsuccessful' do
-      allow(sponsorship).to receive(:save).and_return(false)
-      allow(sponsorship).to receive_message_chain(:errors, :full_messages).and_return('custom message 42')
-      post :create, { orphan_id: 1, sponsor_id: 1, sponsorship_start_date: '2002-02-02' }
-      expect(flash[:warning]).to eq 'custom message 42'
-      expect(flash[:success]).to be_nil
-      expect(response).to redirect_to new_sponsorship_path(sponsor.id, scope: 'eligible_for_sponsorship')
+    context 'when unsuccessful' do
+
+      before(:each) do
+        expect(CreateSponsorship).to receive_message_chain(:new, :call).
+          and_raise('BOOM')
+        post :create, { id: 1, sponsor_id: 1, start_date: '1-1-2000' }
+      end
+
+      it 'sets flash[:warning] message' do
+        expect(flash[:success]).to be_nil
+        expect(flash[:warning]).to eq 'BOOM'
+      end
+
+      it 'redirects to new sponsorship view' do
+        expect(response).to redirect_to new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship')
+      end
     end
   end
 end

--- a/spec/services/create_sponsorship_spec.rb
+++ b/spec/services/create_sponsorship_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'create_sponsorship'
+
+describe CreateSponsorship do
+  let(:sponsor) { FactoryGirl.create :sponsor, requested_orphan_count: 1 }
+  let(:orphan) { FactoryGirl.create :orphan }
+
+  before(:each) do
+    sponsorship = FactoryGirl.build :sponsorship,
+      sponsor: sponsor,
+      orphan: orphan
+    @service = CreateSponsorship.new(sponsorship)
+  end
+
+  describe '#call' do
+    it 'creates a sponsorship' do
+      expect{ @service.call }.to change(Sponsorship, :count).by(1)
+    end
+
+    it 'updates sponsor request_fulfilled' do
+      expect{ @service.call }.to change(sponsor, :request_fulfilled).
+        from(false).to(true)
+    end
+
+    it 'updates sponsor active_sponsorship_count' do
+      expect{ @service.call }.to change(sponsor, :active_sponsorship_count).
+        from(0).to(1)
+    end
+
+    it 'updates orphan sponsorship status' do
+      sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
+
+      expect{ @service.call }.to change(orphan, :orphan_sponsorship_status).
+        to(sponsored_status)
+    end
+  end
+end

--- a/spec/services/create_sponsorship_spec.rb
+++ b/spec/services/create_sponsorship_spec.rb
@@ -4,34 +4,68 @@ require 'create_sponsorship'
 describe CreateSponsorship do
   let(:sponsor) { FactoryGirl.create :sponsor, requested_orphan_count: 1 }
   let(:orphan) { FactoryGirl.create :orphan }
-
-  before(:each) do
-    sponsorship = FactoryGirl.build :sponsorship,
-      sponsor: sponsor,
-      orphan: orphan
-    @service = CreateSponsorship.new(sponsorship)
-  end
+  let(:sponsorship) { FactoryGirl.build :sponsorship, sponsor: sponsor,
+                      orphan: orphan }
+  let(:service) { CreateSponsorship.new(sponsorship) }
 
   describe '#call' do
-    it 'creates a sponsorship' do
-      expect{ @service.call }.to change(Sponsorship, :count).by(1)
+
+    context 'when successful' do
+      it 'creates a sponsorship' do
+        expect{ service.call }.to change(Sponsorship, :count).by(1)
+      end
+
+      it 'updates sponsor request_fulfilled' do
+        expect{ service.call }.to change(sponsor, :request_fulfilled).
+          from(false).to(true)
+      end
+
+      it 'updates sponsor active_sponsorship_count' do
+        expect{ service.call }.to change(sponsor, :active_sponsorship_count).
+          from(0).to(1)
+      end
+
+      it 'updates orphan sponsorship status' do
+        sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
+
+        expect{ service.call }.to change(orphan, :orphan_sponsorship_status).
+          to(sponsored_status)
+      end
+
+      it 'returns true' do
+        expect(service.call).to eq true
+      end
     end
 
-    it 'updates sponsor request_fulfilled' do
-      expect{ @service.call }.to change(sponsor, :request_fulfilled).
-        from(false).to(true)
-    end
+    context 'when unsuccessful' do
+      before do
+        allow(service).to receive(:persist_sponsorship!).and_raise 'BOOM'
+      end
 
-    it 'updates sponsor active_sponsorship_count' do
-      expect{ @service.call }.to change(sponsor, :active_sponsorship_count).
-        from(0).to(1)
-    end
+      it 'does not create a sponsorship' do
+        expect{ service.call }.not_to change(Sponsorship, :count)
+      end
 
-    it 'updates orphan sponsorship status' do
-      sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
+      it 'does not update sponsor request_fulfilled' do
+        expect{ service.call }.not_to change(sponsor, :request_fulfilled)
+      end
 
-      expect{ @service.call }.to change(orphan, :orphan_sponsorship_status).
-        to(sponsored_status)
+      it 'does not update sponsor active_sponsorship_count' do
+        expect{ service.call }.not_to change(sponsor, :active_sponsorship_count)
+      end
+
+      it 'updates orphan sponsorship status' do
+        expect{ service.call }.not_to change(orphan, :orphan_sponsorship_status)
+      end
+
+      it "sets @error_msg to the rescued error's message" do
+        service.call
+        expect(service.error_msg).to eq 'BOOM'
+      end
+
+      it 'returns false' do
+        expect(service.call).to eq false
+      end
     end
   end
 end

--- a/spec/services/destroy_sponsorship_spec.rb
+++ b/spec/services/destroy_sponsorship_spec.rb
@@ -4,35 +4,72 @@ require 'destroy_sponsorship'
 describe DestroySponsorship do
   let(:sponsor) { FactoryGirl.create :sponsor, requested_orphan_count: 1 }
   let(:orphan) { FactoryGirl.create :orphan }
+  let(:sponsorship) { FactoryGirl.build :sponsorship, sponsor: sponsor,
+                      orphan: orphan }
+  let(:service) { DestroySponsorship.new(sponsorship) }
 
-  before(:each) do
-    sponsorship = FactoryGirl.build :sponsorship, sponsor: sponsor,
-      orphan: orphan
-    CreateSponsorship.new(sponsorship).call
-    @service = DestroySponsorship.new(sponsorship)
-  end
+  before { CreateSponsorship.new(sponsorship).call }
 
   describe '#call' do
-    it 'destroys the sponsorship' do
-      expect{ @service.call }.to change(Sponsorship, :count).by(-1)
+
+    context 'when successful' do
+      it 'destroys the sponsorship' do
+        expect{ service.call }.to change(Sponsorship, :count).by(-1)
+      end
+
+      it 'updates sponsor request_fulfilled' do
+        expect{ service.call }.to change(sponsor, :request_fulfilled).
+          from(true).to(false)
+      end
+
+      it 'updates sponsor active_sponsorship_count' do
+        expect{ service.call }.to change(sponsor, :active_sponsorship_count).
+          from(1).to(0)
+      end
+
+      it 'updates orphan sponsorship status' do
+        sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
+        unsponsored_status = OrphanSponsorshipStatus.find_by_name 'Unsponsored'
+
+        expect{ service.call }.to change(orphan, :orphan_sponsorship_status).
+          from(sponsored_status).to(unsponsored_status)
+      end
+
+      it 'return true' do
+        expect(service.call).to eq true
+      end
     end
 
-    it 'updates sponsor request_fulfilled' do
-      expect{ @service.call }.to change(sponsor, :request_fulfilled).
-        from(true).to(false)
-    end
+    context 'when unsuccessful' do
 
-    it 'updates sponsor active_sponsorship_count' do
-      expect{ @service.call }.to change(sponsor, :active_sponsorship_count).
-        from(1).to(0)
-    end
+      before do
+        allow(service).to receive(:destroy_sponsorship!).and_raise 'BOOM'
+      end
 
-    it 'updates orphan sponsorship status' do
-      sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
-      unsponsored_status = OrphanSponsorshipStatus.find_by_name 'Unsponsored'
+      it 'does not destroy the sponsorship' do
+        expect{ service.call }.not_to change(Sponsorship, :count)
+      end
 
-      expect{ @service.call }.to change(orphan, :orphan_sponsorship_status).
-        from(sponsored_status).to(unsponsored_status)
+      it 'does not update sponsor request_fulfilled' do
+        expect{ service.call }.not_to change(sponsor, :request_fulfilled)
+      end
+
+      it 'does not update sponsor active_sponsorship_count' do
+        expect{ service.call }.not_to change(sponsor, :active_sponsorship_count)
+      end
+
+      it 'does not update orphan sponsorship status' do
+        expect{ service.call }.not_to change(orphan, :orphan_sponsorship_status)
+      end
+
+      it 'sets @error_msg' do
+        service.call
+        expect(service.error_msg).to eq 'BOOM'
+      end
+
+      it 'returns false' do
+        expect(service.call).to eq false
+      end
     end
   end
 end

--- a/spec/services/destroy_sponsorship_spec.rb
+++ b/spec/services/destroy_sponsorship_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'destroy_sponsorship'
+
+describe DestroySponsorship do
+  let(:sponsor) { FactoryGirl.create :sponsor, requested_orphan_count: 1 }
+  let(:orphan) { FactoryGirl.create :orphan }
+
+  before(:each) do
+    sponsorship = FactoryGirl.build :sponsorship, sponsor: sponsor,
+      orphan: orphan
+    CreateSponsorship.new(sponsorship).call
+    @service = DestroySponsorship.new(sponsorship)
+  end
+
+  describe '#call' do
+    it 'destroys the sponsorship' do
+      expect{ @service.call }.to change(Sponsorship, :count).by(-1)
+    end
+
+    it 'updates sponsor request_fulfilled' do
+      expect{ @service.call }.to change(sponsor, :request_fulfilled).
+        from(true).to(false)
+    end
+
+    it 'updates sponsor active_sponsorship_count' do
+      expect{ @service.call }.to change(sponsor, :active_sponsorship_count).
+        from(1).to(0)
+    end
+
+    it 'updates orphan sponsorship status' do
+      sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
+      unsponsored_status = OrphanSponsorshipStatus.find_by_name 'Unsponsored'
+
+      expect{ @service.call }.to change(orphan, :orphan_sponsorship_status).
+        from(sponsored_status).to(unsponsored_status)
+    end
+  end
+end

--- a/spec/services/inactivate_sponsorship_spec.rb
+++ b/spec/services/inactivate_sponsorship_spec.rb
@@ -6,40 +6,82 @@ describe InactivateSponsorship do
   let(:orphan) { FactoryGirl.create :orphan }
   let(:sponsorship) { FactoryGirl.build :sponsorship, sponsor: sponsor,
                       orphan: orphan }
+  let(:service) { InactivateSponsorship.new(sponsorship: sponsorship,
+                                            end_date: Date.current) }
 
   before(:each) do
     CreateSponsorship.new(sponsorship).call
-    @service = InactivateSponsorship.new(sponsorship: sponsorship,
-                                         end_date: Date.current)
   end
 
   describe '#call' do
 
-    it 'inactivates sponsorship' do
-      expect{ @service.call }.to change(sponsorship, :active).
-        from(true).to(false)
+    context 'when successful' do
+      it 'inactivates sponsorship' do
+        expect{ service.call }.to change(sponsorship, :active).
+          from(true).to(false)
+      end
+
+      it 'sets sponsorship end_date' do
+        expect{ service.call }.to change(sponsorship, :end_date).
+          from(nil).to(Date.current)
+      end
+
+      it 'updates sponsor request_fulfilled' do
+        expect{ service.call }.to change(sponsor, :request_fulfilled).
+          from(true).to(false)
+      end
+
+      it 'updates sponsor active_sponsorship_count' do
+        expect{ service.call }.to change(sponsor, :active_sponsorship_count).
+          from(1).to(0)
+      end
+
+      it 'updates orphan_sponsorship_status' do
+        previous_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
+
+        expect{ service.call }.to change(orphan, :orphan_sponsorship_status).
+          to(previous_status)
+      end
+
+      it 'returns true' do
+        expect(service.call).to eq true
+      end
     end
 
-    it 'sets sponsorship end_date' do
-      expect{ @service.call }.to change(sponsorship, :end_date).
-        from(nil).to(Date.current)
-    end
+    context 'when unsuccessful' do
 
-    it 'updates sponsor request_fulfilled' do
-      expect{ @service.call }.to change(sponsor, :request_fulfilled).
-        from(true).to(false)
-    end
+      before do
+        allow(service).to receive(:inactivate_sponsorship!).and_raise 'BOOM'
+      end
 
-    it 'updates sponsor active_sponsorship_count' do
-      expect{ @service.call }.to change(sponsor, :active_sponsorship_count).
-        from(1).to(0)
-    end
+      it 'does not inactivate sponsorship' do
+        expect{ service.call }.not_to change(sponsorship, :active)
+      end
 
-    it 'updates orphan_sponsorship_status' do
-      previous_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
+      it 'does not set sponsorship end_date' do
+        expect{ service.call }.not_to change(sponsorship, :end_date)
+      end
 
-      expect{ @service.call }.to change(orphan, :orphan_sponsorship_status).
-        to(previous_status)
+      it 'does not update sponsor request_fulfilled' do
+        expect{ service.call }.not_to change(sponsor, :request_fulfilled)
+      end
+
+      it 'does not update sponsor active_sponsorship_count' do
+        expect{ service.call }.not_to change(sponsor, :active_sponsorship_count)
+      end
+
+      it 'does not update orphan_sponsorship_status' do
+        expect{ service.call }.not_to change(orphan, :orphan_sponsorship_status)
+      end
+
+      it 'sets @error_msg' do
+        service.call
+        expect(service.error_msg).to eq 'BOOM'
+      end
+
+      it 'returns false' do
+        expect(service.call).to eq false
+      end
     end
   end
 end

--- a/spec/services/inactivate_sponsorship_spec.rb
+++ b/spec/services/inactivate_sponsorship_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'inactivate_sponsorship'
+
+describe InactivateSponsorship do
+  let(:sponsor) { FactoryGirl.create :sponsor, requested_orphan_count: 1 }
+  let(:orphan) { FactoryGirl.create :orphan }
+  let(:sponsorship) { FactoryGirl.build :sponsorship, sponsor: sponsor,
+                      orphan: orphan }
+
+  before(:each) do
+    CreateSponsorship.new(sponsorship).call
+    @service = InactivateSponsorship.new(sponsorship: sponsorship,
+                                         end_date: Date.current)
+  end
+
+  describe '#call' do
+
+    it 'inactivates sponsorship' do
+      expect{ @service.call }.to change(sponsorship, :active).
+        from(true).to(false)
+    end
+
+    it 'sets sponsorship end_date' do
+      expect{ @service.call }.to change(sponsorship, :end_date).
+        from(nil).to(Date.current)
+    end
+
+    it 'updates sponsor request_fulfilled' do
+      expect{ @service.call }.to change(sponsor, :request_fulfilled).
+        from(true).to(false)
+    end
+
+    it 'updates sponsor active_sponsorship_count' do
+      expect{ @service.call }.to change(sponsor, :active_sponsorship_count).
+        from(1).to(0)
+    end
+
+    it 'updates orphan_sponsorship_status' do
+      previous_status = OrphanSponsorshipStatus.find_by_name 'Previously Sponsored'
+
+      expect{ @service.call }.to change(orphan, :orphan_sponsorship_status).
+        to(previous_status)
+    end
+  end
+end

--- a/spec/services/resolve_orphan_sponsorship_status_spec.rb
+++ b/spec/services/resolve_orphan_sponsorship_status_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'resolve_orphan_sponsorship_status'
+
+describe ResolveOrphanSponsorshipStatus do
+  let(:orphan) { FactoryGirl.create :orphan }
+  let(:service) { ResolveOrphanSponsorshipStatus.new(orphan) }
+
+  context 'when unsponsored' do
+    it 'returns Unsponsored status' do
+      expect(service.call).to eq 'Unsponsored'
+    end
+  end
+
+  describe 'with sponsorships' do
+    let(:sponsorship) { FactoryGirl.build :sponsorship, orphan: orphan }
+    before do
+      CreateSponsorship.new(sponsorship).call
+    end
+
+    context 'when currently sponsored' do
+      it 'returns Sponsored status' do
+        expect(service.call).to eq 'Sponsored'
+      end
+    end
+
+    context 'when previously sponsored' do
+      before do
+        InactivateSponsorship.new(sponsorship: sponsorship, end_date: Date.current).call
+      end
+
+      it 'returns Previously Sponsored status' do
+        expect(service.call).to eq 'Previously Sponsored'
+      end
+    end
+  end
+end

--- a/spec/services/update_orphan_sponsorship_status_spec.rb
+++ b/spec/services/update_orphan_sponsorship_status_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'update_orphan_sponsorship_status'
+
+describe UpdateOrphanSponsorshipStatus do
+  let(:orphan) { FactoryGirl.create :orphan }
+
+  it 'updates orphan sponsorship status' do
+    sponsored_status = OrphanSponsorshipStatus.find_by_name 'Sponsored'
+    service = UpdateOrphanSponsorshipStatus.new(orphan, 'Sponsored')
+
+    expect{ service.call }.to change(orphan, :orphan_sponsorship_status).
+      to(sponsored_status)
+  end
+end

--- a/spec/services/update_sponsor_sponsorship_data_spec.rb
+++ b/spec/services/update_sponsor_sponsorship_data_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+require 'update_sponsor_sponsorship_data'
+
+describe UpdateSponsorSponsorshipData do
+  let(:sponsor) { FactoryGirl.create :sponsor, requested_orphan_count: 1 }
+  let!(:sponsorship) { FactoryGirl.create :sponsorship, sponsor: sponsor }
+  let(:service) { UpdateSponsorSponsorshipData.new(sponsor) }
+
+  describe '#call' do
+
+    context 'when sponsorship is created' do
+      it 'sets request_fulfilled' do
+        expect{ service.call }.to change(sponsor, :request_fulfilled).
+          from(false).to(true)
+      end
+
+      it 'sets active_sponsorship_count' do
+        expect{ service.call }.to change(sponsor, :active_sponsorship_count).
+          from(0).to(1)
+      end
+    end
+
+    context 'when sponsorship is inactivated' do
+      before do
+        service.call
+        sponsorship.update(active: false, end_date: Date.current)
+      end
+
+      it 'sets request_fulfilled' do
+        expect{ service.call }.to change(sponsor, :request_fulfilled).
+          from(true).to(false)
+      end
+
+      it 'sets active_sponsorship_count' do
+        expect{ service.call }.to change(sponsor, :active_sponsorship_count).
+          from(1).to(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Part IV of IV - replace model callbacks handling sponsorship events with service objects.

_The main point of concern for me in undertaking this was the fact that the Sponsorship model had been made responsible for ensuring that pertinent Sponsor & Orphan objects were updated synchronously whenever the sponsorship changed (was created, destroyed or inactivated). Secondarily, though still importantly, both Sponsor & Orphan had become loaded with many methods that went well beyond the core responsibilities of an AR model, namely persistence, validations & associations._

Here, callbacks and related code are removed from the models as they have now been fully replaced with service objects. Specs & features are updated.

I was initially concerned by the fact that a sponsorship can no longer be properly created via a factory or `Sponsorship.create` - without callbacks in the model, the attendant sponsor & orphan records won't be updated to reflect their association with the sponsorship. However, I've come to see this as much less of a problem over time (if it is a problem at all). The factory and `Sponsorship.create` still produce valid sponsorship objects, which means that the Sponsorship model fully encapsulates its own functionality. Updating sponsor & orphan is, to me, clearly beyond the scope of Sponsorship's responsibilities, and so relying on service objects to effect all the changes that need to occur every time a sponsorship changes feels right to me.