### PR TITLE
OSRA343 require missing file

### DIFF
--- a/spec/views/hq/sponsors/_sponsors_spec.rb
+++ b/spec/views/hq/sponsors/_sponsors_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'cgi'
+require 'will_paginate/array'
 
 RSpec.describe 'hq/sponsors/_sponsors.html.haml', type: :view do
   describe 'sponsors exist' do


### PR DESCRIPTION
This spec fails when run on its own, or when another spec hasn't already required this file