### PR TITLE
Improve Sponsor#currently_sponsored_orphans

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -66,7 +66,8 @@ class Sponsor < ActiveRecord::Base
   end
 
   def currently_sponsored_orphans
-    sponsorships.all_active.map(&:orphan)
+    Orphan.joins(:sponsorships).
+      where(sponsorships: { sponsor_id: self.id, active: true } )
   end
 
   def self.all_cities


### PR DESCRIPTION
Change implementation of `Sponsor#currently_sponsored_orphans` method to
retrieve the orphan records entirely via a db query and to return an AR
relation rather than array