### PR TITLE
OSRA-340 Sponsor instance action items

### DIFF
--- a/app/views/hq/sponsors/show.html.haml
+++ b/app/views/hq/sponsors/show.html.haml
@@ -1,7 +1,9 @@
 %div.action_items
   %div.instance
-    = link_to 'Edit Sponsor', edit_hq_sponsor_path(@sponsor.id), 
-        class: 'btn btn-default', role: 'button'
+    = link_to 'Edit Sponsor', edit_hq_sponsor_path(@sponsor.id),
+      class: 'btn btn-default', role: 'button'
+    = link_to 'Link to Orphan', '#',
+      class: 'btn btn-default', role: 'button'
 
 %dl.dl-horizontal
   %dt Sponsor Name

--- a/spec/views/hq/sponsors/show_spec.rb
+++ b/spec/views/hq/sponsors/show_spec.rb
@@ -7,16 +7,19 @@ RSpec.describe "hq/sponsors/show.html.haml", type: :view do
   describe 'the sponsor exists' do
     before :each do
       assign(:sponsor, sponsor)
+      render
     end
 
     it 'should show the assigned sponsor details' do
-      render and expect(rendered).to match sponsor.name
+      expect(rendered).to match sponsor.name
     end
 
     it 'should have an Edit Sponsor button' do
-      render
-
       expect(rendered).to have_link('Edit Sponsor', edit_hq_sponsor_path(sponsor.id))
+    end
+
+    it 'should have a Link to Orphan button' do
+      expect(rendered).to have_link('Link to Orphan')
     end
   end
 


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-340

Add placeholder button 'Link to Orphan'. Correct path to be added after the
Orphan and Sponsorship controllers & views are converted to pure Rails.