### PR TITLE
OSRA-120 Create and Add Another Sponsor (HQ)

### DIFF
--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -49,8 +49,16 @@ private
 
   def save_sponsor
     if @sponsor.save
-      flash[:success]= "Sponsor successfuly saved"
-      redirect_to hq_sponsor_url(@sponsor)
+      flash[:success]= "Sponsor successfuly created"
+      redirect_to_new_or_saved_sponsor
+    end
+  end
+
+  def redirect_to_new_or_saved_sponsor
+    if params[:commit] == 'Create and Add Another'
+      redirect_to new_hq_sponsor_path
+    else
+      redirect_to hq_sponsor_path(@sponsor)
     end
   end
 

--- a/app/views/hq/sponsors/_form.html.haml
+++ b/app/views/hq/sponsors/_form.html.haml
@@ -92,6 +92,8 @@
 
   .form-group
     = f.submit class: 'btn btn-primary'
+    - if f.object.new_record?
+      = f.submit 'Create and Add Another', class: 'btn btn-primary'
     = link_to 'Cancel',
                 f.object.new_record? ? hq_sponsors_path : hq_sponsor_path(f.object.id),
                 class: 'btn btn-default btn-cancel', role: 'button'

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe Hq::SponsorsController, type: :controller do
       expect(response).to redirect_to hq_sponsor_url(assigns :sponsor)
     end
 
+    specify 'redirects to new when user clicks Create and Add Another' do
+      post :create, sponsor: build(:sponsor).attributes,
+        commit: 'Create and Add Another'
+
+      expect(response).to redirect_to new_hq_sponsor_path
+    end
+
     specify 'unsuccessful' do
       expect_any_instance_of(Sponsor).to receive(:save).and_return(false)
       post :create, sponsor: build(:sponsor).attributes

--- a/spec/features/user_is_creating_multiple_sponsors_spec.rb
+++ b/spec/features/user_is_creating_multiple_sponsors_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'User enters new sponsor data', :type => :feature do
+
+  background do
+    an_agent_exists
+    i_sign_in_as_admin
+  end
+
+  scenario 'User clicks the Create and Add Another button' do
+    when_i_enter_new_sponsor_info
+    and_i_click_create_and_add_another_button
+
+    then_the_sponsor_should_be_saved
+    and_i_should_be_on_new_sponsor_page
+  end
+end
+
+def an_agent_exists
+  FactoryGirl.create :agent
+end
+
+def i_sign_in_as_admin
+  admin = FactoryGirl.create :admin_user
+  visit new_admin_user_session_path
+  fill_in 'Email', with: admin.email
+  fill_in 'Password', with: admin.password
+  click_button 'Login'
+end
+
+def when_i_enter_new_sponsor_info
+  visit new_hq_sponsor_path
+  fill_in 'Name', with: 'C. Montgomery Burns'
+  fill_in 'Requested orphan count', with: '1'
+  select 'London', from: 'sponsor[branch_id]'
+  fill_in 'New city name', with: 'London'
+  select User.first.user_name, from: 'sponsor[agent_id]'
+end
+
+def and_i_click_create_and_add_another_button
+  click_button 'Create and Add Another'
+end
+
+def then_the_sponsor_should_be_saved
+  expect(page).to have_text 'Sponsor successfuly created'
+  expect(Sponsor.last.name).to eq 'C. Montgomery Burns'
+end
+
+def and_i_should_be_on_new_sponsor_page
+  expect(current_path).to eq new_hq_sponsor_path
+end

--- a/spec/support/view_helpers.rb
+++ b/spec/support/view_helpers.rb
@@ -1,0 +1,14 @@
+module ViewHelpers
+  def show_me_rendered
+    require 'launchy'
+    filename = "tmp/view_spec_render-#{Time.now.to_i}.html"
+    File.open(filename, 'w') { |file| file.write(rendered) }
+    Launchy.open filename
+  rescue LoadError
+    warn 'You need to install launchy to open pages: `gem install launchy`'
+  end
+end
+
+RSpec.configure do |c|
+  c.include ViewHelpers, :type => :view
+end

--- a/spec/views/hq/sponsors/edit_spec.rb
+++ b/spec/views/hq/sponsors/edit_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe 'hq/sponsors/edit.html.haml', type: :view do
     assign :organizations, []
     assign :branches, []
     assign :cities, []
+
+    render
   end
 
   it 'renders the form partial' do
-    render
-
     expect(view).to render_template(partial: '_form')
   end
 
+  it 'does not render the Create and Add Another button' do
+    expect(rendered).not_to have_button 'Create and Add Another'
+  end
 end

--- a/spec/views/hq/sponsors/new_spec.rb
+++ b/spec/views/hq/sponsors/new_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe 'hq/sponsors/new.html.haml', type: :view do
     assign :organizations, []
     assign :branches, []
     assign :cities, []
+
+    render
   end
 
   it 'renders the form partial' do
-    render
-
     expect(view).to render_template(partial: '_form')
   end
 
+  it 'renders the Create and Add Another button' do
+    expect(rendered).to have_button 'Create and Add Another'
+  end
 end


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-120

Add 'Create and Add Another' button to new sponsor page _in the HQ namespace_ (AA still to come).
 - add conditionally rendered button to the sponsor form
 - modify `sponsors_controller#save_sponsor` to parse `params[:commit]`
 - add button tests to new & edit view specs
 - create RSpec feature to test new record creation & redirect to new sponsor view - discuss!
 - add RSpec helper method to show rendered views in browser (`save_and_open_page` does not work for rendered pages in view specs)
![screen shot 2015-02-19 at 10 14 46 pm](https://cloud.githubusercontent.com/assets/5029403/6275238/39d716c2-b886-11e4-8b31-2db5d3b4c0b7.png)
