### PR TITLE
OSRA-120 Create and Add Another Sponsor (AA)

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -149,6 +149,9 @@ ActiveAdmin.register Sponsor do
     end
     f.actions do
       f.action :submit
+      if f.object.new_record?
+        f.action :submit, :label => 'Create and Add Another'
+      end
       f.action :cancel, :label => "Cancel", :wrapper_html => { :class => "cancel" }
     end
   end
@@ -159,6 +162,30 @@ ActiveAdmin.register Sponsor do
 
   action_item :link_to_orphan, only: :show do
     link_to 'Link to Orphan', new_sponsorship_path(sponsor, scope: 'eligible_for_sponsorship') if sponsor.eligible_for_sponsorship?
+  end
+
+  controller do
+    def create
+      @sponsor = Sponsor.new(permitted_params[:sponsor])
+      save_sponsor or render 'new'
+    end
+
+    private
+
+    def save_sponsor
+      if @sponsor.save
+        flash[:success] = 'Sponsor was successfully created'
+        redirect_to_new_or_saved_sponsor
+      end
+    end
+
+    def redirect_to_new_or_saved_sponsor
+      if params[:commit] == 'Create and Add Another'
+        redirect_to new_admin_sponsor_path
+      else
+        redirect_to admin_sponsor_path @sponsor
+      end
+    end
   end
 
   permit_params :name, :country, :gender, :requested_orphan_count, :address,

--- a/features/aa/aa_features/sponsor.feature
+++ b/features/aa/aa_features/sponsor.feature
@@ -181,3 +181,9 @@ Feature:
     Then I should see "(Cayman Islands)"
     When I am on the "Show Sponsor" page for sponsor "Obscure Sponsor"
     Then I should see "(Cayman Islands)"
+
+  Scenario: Create and Add Another workflow
+    Given I enter valid new sponsor data
+    And I click the "Create and Add Another" button
+    Then I should be on the "New Sponsor" page for the "Admin" role
+    And I should see "Sponsor was successfully created"

--- a/features/aa/step_definitions/aa_steps/sponsors_steps.rb
+++ b/features/aa/step_definitions/aa_steps/sponsors_steps.rb
@@ -93,3 +93,19 @@ end
 Given /^"([^"]*)" is from (?:.*)-([A-Z]{2})$/ do |name, country_code|
   FactoryGirl.create(:sponsor, name: name, country: country_code)
 end
+
+Given /I enter valid new sponsor data/ do
+  steps %Q{
+    Given a user "Agent One" exists
+    And I am on the "New Sponsor" page for the "Admin" role
+    And I fill in "Name" with "Sponsor4"
+    And I fill in "Requested orphan count" with "22"
+    And I select "Canada" from the drop down box for "Country"
+    And I select "Toronto" from the drop down box for "City"
+    And I select "Male" from the drop down box for "Gender"
+    And I select "Jeddah" from the drop down box for "Branch"
+    And I select "Individual" from the drop down box for "Sponsor type"
+    And I select "Agent One" from the drop down box for "Agent"
+    And I select "Every Six Months" from the drop down box for "Payment plan"
+  }
+end

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+include Devise::TestHelpers
+
+RSpec.describe Admin::SponsorsController, :type => :controller do
+
+  let(:sponsor) { instance_double Sponsor }
+  before(:each) { sign_in instance_double AdminUser }
+
+  describe '#create' do
+
+    before(:each) { allow(Sponsor).to receive(:new).and_return(sponsor) }
+
+    context 'when successful' do
+
+      before(:each) { allow(sponsor).to receive(:save).and_return(true) }
+
+      it 'redirects to created sponsor if user clicks Create Sponsor' do
+        post :create, sponsor: {}, commit: 'Submit'
+
+        expect(response).to redirect_to admin_sponsor_path(sponsor)
+        expect(flash[:success]).to eq 'Sponsor was successfully created'
+      end
+
+      it 'redirects to new if user clicks Create and Add Another' do
+        post :create, sponsor: {}, commit: 'Create and Add Another'
+
+        expect(response).to redirect_to new_admin_sponsor_path
+        expect(flash[:success]).to eq 'Sponsor was successfully created'
+      end
+    end
+
+    context 'when unsuccessful' do
+
+      before(:each) { allow(sponsor).to receive(:save).and_return(false) }
+
+      it 'renders new' do
+        post :create, sponsor: {}, commit: 'Submit'
+
+        expect(response).to render_template 'new'
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-120

 - add 'Create and Add Another' button to New Sponsor view
 - override admin `sponsors_controller#create` to parse params[:commit]
 - write Cucumber scenario & controller spec