### PR TITLE
osra392 Add "Sponsored Orphans" list to the sponsor show view

### DIFF
--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -49,7 +49,7 @@ private
   end
 
   def load_active_and_inactive_sponsorships
-    sponsorships = Sponsorship.load_with_orphans_for_sponsor @sponsor.id
+    sponsorships = Sponsorship.load_with_orphans_for @sponsor
     @sponsorships_active = sponsorships.select {|sp| sp.active == true}
     @sponsorships_inactive = sponsorships.select {|sp| sp.active == false}
   end

--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -49,7 +49,7 @@ private
   end
 
   def load_active_and_inactive_sponsorships
-    sponsorships = Sponsorship.where("sponsor_id = ?", @sponsor.id).eager_load(:orphan).all
+    sponsorships = Sponsorship.load_with_orphans_for_sponsor @sponsor.id
     @sponsorships_active = sponsorships.select {|sp| sp.active == true}
     @sponsorships_inactive = sponsorships.select {|sp| sp.active == false}
   end

--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -49,7 +49,7 @@ private
   end
 
   def load_active_and_inactive_sponsorships
-    sponsorships = Sponsorship.where("sponsor_id = ?", @sponsor.id).eager_load(:orphan, :sponsor).all
+    sponsorships = Sponsorship.where("sponsor_id = ?", @sponsor.id).eager_load(:orphan).all
     @sponsorships_active = sponsorships.select {|sp| sp.active == true}
     @sponsorships_inactive = sponsorships.select {|sp| sp.active == false}
   end

--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -4,9 +4,8 @@ class Hq::SponsorsController < HqController
   end
 
   def show
-    @sponsor = Sponsor.find(params[:id])   #.includes(:sponsorships)
-    @sponsorships_active = @sponsor.sponsorships.select {|sp| sp.active == true}
-    @sponsorships_inactive = @sponsor.sponsorships.select {|sp| sp.active == false}
+    load_sponsor
+    load_active_and_inactive_sponsorships
   end
 
   def new
@@ -47,6 +46,12 @@ private
 
   def load_sponsor
     @sponsor= Sponsor.find(params[:id])
+  end
+
+  def load_active_and_inactive_sponsorships
+    sponsorships = Sponsorship.where("sponsor_id = ?", @sponsor.id).eager_load(:orphan, :sponsor).all
+    @sponsorships_active = sponsorships.select {|sp| sp.active == true}
+    @sponsorships_inactive = sponsorships.select {|sp| sp.active == false}
   end
 
   def save_sponsor

--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -4,7 +4,9 @@ class Hq::SponsorsController < HqController
   end
 
   def show
-    @sponsor = Sponsor.find(params[:id])
+    @sponsor = Sponsor.find(params[:id])   #.includes(:sponsorships)
+    @sponsorships_active = @sponsor.sponsorships.select {|sp| sp.active == true}
+    @sponsorships_inactive = @sponsor.sponsorships.select {|sp| sp.active == false}
   end
 
   def new

--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -49,7 +49,7 @@ private
   end
 
   def load_active_and_inactive_sponsorships
-    sponsorships = Sponsorship.load_with_orphans_for @sponsor
+    sponsorships = Sponsorship.where(sponsor: @sponsor)
     @sponsorships_active = sponsorships.select {|sp| sp.active == true}
     @sponsorships_inactive = sponsorships.select {|sp| sp.active == false}
   end

--- a/app/controllers/hq/sponsorships_controller.rb
+++ b/app/controllers/hq/sponsorships_controller.rb
@@ -2,18 +2,20 @@ class Hq::SponsorshipsController < HqController
 
   def inactivate
     sponsorship = Sponsorship.find(params[:id])
+    sponsor = sponsorship.sponsor
 
     @sponsorship_inactivator = InactivateSponsorship.new(sponsorship: sponsorship,
                                                          end_date: params[:sponsorship][:end_date])
-    inactivate_sponsorship and redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+    inactivate_sponsorship and redirect_to hq_sponsor_path(sponsor)
   end
 
   def destroy
     sponsorship = Sponsorship.find(params[:id])
+    sponsor = sponsorship.sponsor
 
     @sponsorship_destructor = DestroySponsorship.new(sponsorship)
 
-    destroy_sponsorship and redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+    destroy_sponsorship and redirect_to hq_sponsor_path(sponsor)
   end
 
   private

--- a/app/controllers/hq/sponsorships_controller.rb
+++ b/app/controllers/hq/sponsorships_controller.rb
@@ -2,22 +2,36 @@ class Hq::SponsorshipsController < HqController
 
   def inactivate
     sponsorship = Sponsorship.find(params[:id])
-    if sponsorship.inactivate params[:sponsorship][:end_date]
-      flash[:success] = 'Sponsorship link was successfully terminated'
-    else
-      flash[:error] = sponsorship.errors.full_messages || 'Sponsorship not terminated'
-    end
-    redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+
+    @sponsorship_inactivator = InactivateSponsorship.new(sponsorship: sponsorship,
+                                                         end_date: params[:sponsorship][:end_date])
+    inactivate_sponsorship and redirect_to hq_sponsor_path(sponsorship.sponsor_id)
   end
 
   def destroy
     sponsorship = Sponsorship.find(params[:id])
-    if sponsorship.destroy
-      flash[:success] = 'Sponsorship was successfully deleted'
+
+    @sponsorship_destructor = DestroySponsorship.new(sponsorship)
+
+    destroy_sponsorship and redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+  end
+
+  private
+
+  def inactivate_sponsorship
+    if @sponsorship_inactivator.call
+      flash[:success] = 'Sponsorship link was successfully terminated.'
     else
-      flash[:error] = 'Sponsorship not deleted'
+      flash[:error] = @sponsorship_inactivator.error_msg
     end
-    redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+  end
+
+  def destroy_sponsorship
+    if @sponsorship_destructor.call
+      flash[:success] = 'Sponsorship record was successfully destroyed.'
+    else
+      flash[:error] = @sponsorship_destructor.error_msg
+    end
   end
 
 end

--- a/app/controllers/hq/sponsorships_controller.rb
+++ b/app/controllers/hq/sponsorships_controller.rb
@@ -1,0 +1,23 @@
+class Hq::SponsorshipsController < HqController
+
+  def inactivate
+    sponsorship = Sponsorship.find(params[:id])
+    if sponsorship.inactivate params[:sponsorship][:end_date]
+      flash[:success] = 'Sponsorship link was successfully terminated'
+    else
+      flash[:error] = sponsorship.errors.full_messages || 'Sponsorship not terminated'
+    end
+    redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+  end
+
+  def destroy
+    sponsorship = Sponsorship.find(params[:id])
+    if sponsorship.destroy
+      flash[:success] = 'Sponsorship was successfully deleted'
+    else
+      flash[:error] = 'Sponsorship not deleted'
+    end
+    redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+  end
+
+end

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -28,6 +28,8 @@ class Sponsorship < ActiveRecord::Base
 
   scope :all_active, -> { where(active: true) }
   scope :all_inactive, -> { where(active: false) }
+  scope :load_with_orphans_for_sponsor,
+         ->(sponsor_id) {where("sponsor_id = ?", sponsor_id).eager_load(:orphan).all}
 
 private
 

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -28,8 +28,8 @@ class Sponsorship < ActiveRecord::Base
 
   scope :all_active, -> { where(active: true) }
   scope :all_inactive, -> { where(active: false) }
-  scope :load_with_orphans_for,
-        ->(sponsor) {where(sponsor: sponsor).eager_load(:orphan).all}
+  
+  default_scope { includes(:sponsor, :orphan) }
 
 private
 

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -28,8 +28,8 @@ class Sponsorship < ActiveRecord::Base
 
   scope :all_active, -> { where(active: true) }
   scope :all_inactive, -> { where(active: false) }
-  scope :load_with_orphans_for_sponsor,
-         ->(sponsor_id) {where("sponsor_id = ?", sponsor_id).eager_load(:orphan).all}
+  scope :load_with_orphans_for,
+        ->(sponsor) {where(sponsor: sponsor).eager_load(:orphan).all}
 
 private
 

--- a/app/views/hq/sponsors/_sponsorships_active.html.haml
+++ b/app/views/hq/sponsors/_sponsorships_active.html.haml
@@ -1,0 +1,47 @@
+- if sponsorships.empty?
+  .panel.panel-default
+    .panel-body
+      No currently sponsored orphans
+- else
+  .table-responsive
+    %table.table
+      .table_title
+        = "#{sponsorships.count} currently sponsored #{'orphan'.pluralize(sponsorships.count)}"
+      %thead
+        %tr
+          %th
+            Orphan name
+          %th
+            Orphan date of birth
+          %th
+            Orphan gender
+          %th
+            Sponsorship Began
+          %th
+
+          %th
+
+      %tbody
+        - sponsorships.each do |sponsorship|
+          %tr
+            %td
+              = link_to sponsorship.orphan.name, hq_orphan_path(sponsorship.orphan)
+            %td
+              = sponsorship.orphan.date_of_birth
+            %td
+              = sponsorship.orphan.gender
+            %td
+              = sponsorship.start_date
+            %td
+              =form_for(sponsorship,
+                  :url => {controller: :sponsorships, action: :inactivate, sponsor_id: sponsorship.sponsor_id, id: sponsorship.id},
+                  method: :put) do |f|
+                =f.submit "End Sponsorship", class: "btn btn-default"
+                =f.label :end_date, "on"
+                =f.text_field :end_date, value: Date.current
+            %td
+              =link_to "Delete",
+                  hq_sponsor_sponsorship_path(sponsorship.sponsor_id, sponsorship),
+                  method: :delete,
+                  data: { confirm: 'WARNING: You are about to permanently delete the record of this sponsorship!'},
+                  class: "btn btn-default"

--- a/app/views/hq/sponsors/_sponsorships_active.html.haml
+++ b/app/views/hq/sponsors/_sponsorships_active.html.haml
@@ -34,14 +34,14 @@
               = sponsorship.start_date
             %td
               =form_for(sponsorship,
-                  :url => {controller: :sponsorships, action: :inactivate, sponsor_id: sponsorship.sponsor_id, id: sponsorship.id},
+                  :url => {controller: :sponsorships, action: :inactivate, id: sponsorship.id},
                   method: :put) do |f|
                 =f.submit "End Sponsorship", class: "btn btn-default"
                 =f.label :end_date, "on"
                 =f.text_field :end_date, value: Date.current
             %td
               =link_to "X",
-                  hq_sponsor_sponsorship_path(sponsorship.sponsor_id, sponsorship),
+                  hq_sponsorship_path(sponsorship),
                   method: :delete,
                   data: { confirm: 'WARNING: You are about to permanently delete the record of this sponsorship!'},
                   class: "btn btn-default btn-xs btn-danger"

--- a/app/views/hq/sponsors/_sponsorships_active.html.haml
+++ b/app/views/hq/sponsors/_sponsorships_active.html.haml
@@ -40,8 +40,8 @@
                 =f.label :end_date, "on"
                 =f.text_field :end_date, value: Date.current
             %td
-              =link_to "Delete",
+              =link_to "X",
                   hq_sponsor_sponsorship_path(sponsorship.sponsor_id, sponsorship),
                   method: :delete,
                   data: { confirm: 'WARNING: You are about to permanently delete the record of this sponsorship!'},
-                  class: "btn btn-default"
+                  class: "btn btn-default btn-xs btn-danger"

--- a/app/views/hq/sponsors/_sponsorships_inactive.html.haml
+++ b/app/views/hq/sponsors/_sponsorships_inactive.html.haml
@@ -1,0 +1,34 @@
+- if sponsorships.empty?
+  .panel.panel-default
+    .panel-body
+      No previously sponsored orphans
+- else
+  .table-responsive
+    %table.table
+      .table_title
+        = "#{sponsorships.count} previously sponsored #{'orphan'.pluralize(sponsorships.count)}"
+      %thead
+        %tr
+          %th
+            Orphan name
+          %th
+            Orphan date of birth
+          %th
+            Orphan gender
+          %th
+            Sponsorship Began
+          %th
+            Sponsorship Ended
+      %tbody
+        - sponsorships.each do |sponsorship|
+          %tr
+            %td
+              = link_to sponsorship.orphan.name, hq_orphan_path(sponsorship.orphan)
+            %td
+              = sponsorship.orphan.date_of_birth
+            %td
+              = sponsorship.orphan.gender
+            %td
+              = sponsorship.start_date
+            %td
+              = sponsorship.end_date

--- a/app/views/hq/sponsors/show.html.haml
+++ b/app/views/hq/sponsors/show.html.haml
@@ -85,3 +85,6 @@
   %dt Updated at
   %dd
     = format_full_date @sponsor.updated_at
+
+= render partial: 'hq/sponsors/sponsorships_active.html.haml', locals: {sponsorships: @sponsorships_active}
+= render partial: 'hq/sponsors/sponsorships_inactive.html.haml', locals: {sponsorships: @sponsorships_inactive}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,4 +26,7 @@ Osra::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = true
+
+  #disable the default querry caching
+  # config.middleware.delete "ActiveRecord::QuerryCache"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,5 +28,5 @@ Osra::Application.configure do
   config.assets.debug = true
 
   #disable the default querry caching
-  # config.middleware.delete "ActiveRecord::QuerryCache"
+  # config.middleware.delete "ActiveRecord::QueryCache"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,6 @@ Osra::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  #disable the default querry caching
+  #disable the default query caching
   # config.middleware.delete "ActiveRecord::QueryCache"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,11 @@ Osra::Application.routes.draw do
       end
     end
     resources :users, except: [:destroy]
-    resources :sponsors, except: [:destroy]
+    resources :sponsors, except: [:destroy] do
+      resources :sponsorships, only: :destroy do
+        put "inactivate", on: :member
+      end
+    end
     resources :orphans, except: [:destroy]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Osra::Application.routes.draw do
     end
     resources :users, except: [:destroy]
     resources :sponsors, except: [:destroy] do
-      resources :sponsorships, only: :destroy do
+      resources :sponsorships, only: :destroy , shallow: true do
         put "inactivate", on: :member
       end
     end

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Hq::SponsorsController, type: :controller do
 
   specify '#show' do
     expect(Sponsor).to receive(:find).and_return(sponsor)
+    expect(Sponsorship).to receive_message_chain(:where, :eager_load,:all).
+                           and_return(sponsorships_active + sponsorships_inactive)
     get :show, id: sponsor.id
     expect(assigns(:sponsor)).to eq sponsor
     expect(assigns(:sponsorships_active)).to eq sponsorships_active

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 require 'will_paginate/array'
 
 RSpec.describe Hq::SponsorsController, type: :controller do
-    let(:sponsor) {build_stubbed :sponsor}
+    let(:sponsorships_active) {(1..3).map {build_stubbed :sponsorship, active: true}}
+    let(:sponsorships_inactive) {(1..2).map {build_stubbed :sponsorship, active: false}}
+    let(:sponsor) {build_stubbed :sponsor, sponsorships: (sponsorships_active + sponsorships_inactive)}
     let(:sponsors) {(1..5).map {build_stubbed :sponsor}}
 
   before :each do
@@ -21,6 +23,8 @@ RSpec.describe Hq::SponsorsController, type: :controller do
     expect(Sponsor).to receive(:find).and_return(sponsor)
     get :show, id: sponsor.id
     expect(assigns(:sponsor)).to eq sponsor
+    expect(assigns(:sponsorships_active)).to eq sponsorships_active
+    expect(assigns(:sponsorships_inactive)).to eq sponsorships_inactive
     expect(response).to render_template 'show'
   end
 

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 require 'will_paginate/array'
 
 RSpec.describe Hq::SponsorsController, type: :controller do
-    let(:sponsorships_active) {build_stubbed_list :sponsorship, 3, active: true}
-
-    let(:sponsorships_inactive) {build_stubbed_list :sponsorship, 2, active: false}
-    let(:sponsor) {build_stubbed :sponsor, sponsorships: (sponsorships_active + sponsorships_inactive)}
-    let(:sponsors) {build_stubbed_list :sponsor, 5}
+  let(:sponsorships_active) {build_stubbed_list :sponsorship, 3, active: true}
+  let(:sponsorships_inactive) {build_stubbed_list :sponsorship, 2, active: false}
+  let(:sponsor_with_sponsorships) {build_stubbed :sponsor, sponsorships: (sponsorships_active + sponsorships_inactive)}
+  let(:sponsor) {build_stubbed :sponsor}
+  let(:sponsors) {build_stubbed_list :sponsor, 5}
 
   before :each do
     sign_in instance_double(AdminUser)
@@ -21,11 +21,11 @@ RSpec.describe Hq::SponsorsController, type: :controller do
   end
 
   specify '#show' do
-    expect(Sponsor).to receive(:find).and_return(sponsor)
+    expect(Sponsor).to receive(:find).and_return(sponsor_with_sponsorships)
     expect(Sponsorship).to receive_message_chain(:where, :eager_load, :all).
                            and_return(sponsorships_active + sponsorships_inactive)
-    get :show, id: sponsor.id
-    expect(assigns(:sponsor)).to eq sponsor
+    get :show, id: sponsor_with_sponsorships.id
+    expect(assigns(:sponsor)).to eq sponsor_with_sponsorships
     expect(assigns(:sponsorships_active)).to eq sponsorships_active
     expect(assigns(:sponsorships_inactive)).to eq sponsorships_inactive
     expect(response).to render_template 'show'

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Hq::SponsorsController, type: :controller do
 
   specify '#show' do
     expect(Sponsor).to receive(:find).and_return(sponsor_with_sponsorships)
-    expect(Sponsorship).to receive_message_chain(:where, :eager_load, :all).
-                           and_return(sponsorships_active + sponsorships_inactive)
+    expect(Sponsorship).to receive(:where).and_return(sponsorships_active + sponsorships_inactive)
     get :show, id: sponsor_with_sponsorships.id
+    
     expect(assigns(:sponsor)).to eq sponsor_with_sponsorships
     expect(assigns(:sponsorships_active)).to eq sponsorships_active
     expect(assigns(:sponsorships_inactive)).to eq sponsorships_inactive

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 require 'will_paginate/array'
 
 RSpec.describe Hq::SponsorsController, type: :controller do
-    let(:sponsorships_active) {(1..3).map {build_stubbed :sponsorship, active: true}}
-    let(:sponsorships_inactive) {(1..2).map {build_stubbed :sponsorship, active: false}}
+    let(:sponsorships_active) {build_stubbed_list :sponsorship, 3, active: true}
+
+    let(:sponsorships_inactive) {build_stubbed_list :sponsorship, 2, active: false}
     let(:sponsor) {build_stubbed :sponsor, sponsorships: (sponsorships_active + sponsorships_inactive)}
-    let(:sponsors) {(1..5).map {build_stubbed :sponsor}}
+    let(:sponsors) {build_stubbed_list :sponsor, 5}
 
   before :each do
     sign_in instance_double(AdminUser)
@@ -21,7 +22,7 @@ RSpec.describe Hq::SponsorsController, type: :controller do
 
   specify '#show' do
     expect(Sponsor).to receive(:find).and_return(sponsor)
-    expect(Sponsorship).to receive_message_chain(:where, :eager_load,:all).
+    expect(Sponsorship).to receive_message_chain(:where, :eager_load, :all).
                            and_return(sponsorships_active + sponsorships_inactive)
     get :show, id: sponsor.id
     expect(assigns(:sponsor)).to eq sponsor

--- a/spec/controllers/hq/sponsorships_controller_spec.rb
+++ b/spec/controllers/hq/sponsorships_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Hq::SponsorshipsController, type: :controller do
+  let(:sponsorship) {create :sponsorship, active: true}
+
+  before :each do
+    sign_in instance_double(AdminUser)
+  end
+
+  specify "#inactivate" do
+    expect(Sponsorship).to receive(:find).and_return(sponsorship)
+    put :inactivate, id: sponsorship.id, sponsor_id: sponsorship.sponsor_id, sponsorship: {end_date: Date.current}
+
+    expect(sponsorship.active).to be false
+    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+  end
+
+  specify "#destroy" do
+    expect(Sponsorship).to receive(:find).and_return(sponsorship)
+    expect(sponsorship).to receive(:destroy).and_return(true)
+    delete :destroy, id: sponsorship.id, sponsor_id: sponsorship.sponsor_id
+
+    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+  end
+end

--- a/spec/controllers/hq/sponsorships_controller_spec.rb
+++ b/spec/controllers/hq/sponsorships_controller_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Hq::SponsorshipsController, type: :controller do
 
   specify "#inactivate" do
     expect(Sponsorship).to receive(:find).and_return(sponsorship)
+    expect(sponsorship).to receive(:update!)
     put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
 
-    expect(sponsorship.active).to be false
     expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
+    expect(flash[:success]).to_not be_nil
   end
 
   specify "#destroy" do
@@ -21,5 +22,6 @@ RSpec.describe Hq::SponsorshipsController, type: :controller do
     delete :destroy, id: sponsorship.id
 
     expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
+    expect(flash[:success]).to_not be_nil
   end
 end

--- a/spec/controllers/hq/sponsorships_controller_spec.rb
+++ b/spec/controllers/hq/sponsorships_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hq::SponsorshipsController, type: :controller do
 
   specify "#destroy" do
     expect(Sponsorship).to receive(:find).and_return(sponsorship)
-    expect(sponsorship).to receive(:destroy).and_return(true)
+    expect(sponsorship).to receive(:destroy!)
     delete :destroy, id: sponsorship.id
 
     expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)

--- a/spec/controllers/hq/sponsorships_controller_spec.rb
+++ b/spec/controllers/hq/sponsorships_controller_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe Hq::SponsorshipsController, type: :controller do
 
   specify "#inactivate" do
     expect(Sponsorship).to receive(:find).and_return(sponsorship)
-    put :inactivate, id: sponsorship.id, sponsor_id: sponsorship.sponsor_id, sponsorship: {end_date: Date.current}
+    put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
 
     expect(sponsorship.active).to be false
-    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
   end
 
   specify "#destroy" do
     expect(Sponsorship).to receive(:find).and_return(sponsorship)
     expect(sponsorship).to receive(:destroy).and_return(true)
-    delete :destroy, id: sponsorship.id, sponsor_id: sponsorship.sponsor_id
+    delete :destroy, id: sponsorship.id
 
-    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor_id)
+    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
   end
 end

--- a/spec/controllers/hq/sponsorships_controller_spec.rb
+++ b/spec/controllers/hq/sponsorships_controller_spec.rb
@@ -7,21 +7,43 @@ RSpec.describe Hq::SponsorshipsController, type: :controller do
     sign_in instance_double(AdminUser)
   end
 
-  specify "#inactivate" do
-    expect(Sponsorship).to receive(:find).and_return(sponsorship)
-    expect(sponsorship).to receive(:update!)
-    put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
+  context "#inactivate" do
+    specify "successful" do
+      expect(Sponsorship).to receive(:find).and_return(sponsorship)
+      expect(sponsorship).to receive(:update!)
+      put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
 
-    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
-    expect(flash[:success]).to_not be_nil
+      expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
+      expect(flash[:success]).to_not be_nil
+    end
+
+    specify "unsuccessful" do
+      expect(Sponsorship).to receive(:find).and_return(sponsorship)
+      expect(sponsorship).to receive(:update!).and_raise
+      put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
+
+      expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
+      expect(flash[:error]).to_not be_nil
+    end
   end
 
-  specify "#destroy" do
-    expect(Sponsorship).to receive(:find).and_return(sponsorship)
-    expect(sponsorship).to receive(:destroy!)
-    delete :destroy, id: sponsorship.id
+  context "#destroy" do
+    specify "successful" do
+      expect(Sponsorship).to receive(:find).and_return(sponsorship)
+      expect(sponsorship).to receive(:destroy!)
+      delete :destroy, id: sponsorship.id
 
-    expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
-    expect(flash[:success]).to_not be_nil
+      expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
+      expect(flash[:success]).to_not be_nil
+    end
+
+    specify "unsuccessful" do
+      expect(Sponsorship).to receive(:find).and_return(sponsorship)
+      expect(sponsorship).to receive(:destroy!).and_raise
+      delete :destroy, id: sponsorship.id
+
+      expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
+      expect(flash[:error]).to_not be_nil
+    end
   end
 end

--- a/spec/controllers/hq/sponsorships_controller_spec.rb
+++ b/spec/controllers/hq/sponsorships_controller_spec.rb
@@ -1,36 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe Hq::SponsorshipsController, type: :controller do
-  let(:sponsorship) {create :sponsorship, active: true}
+  let(:sponsorship) {build_stubbed :sponsorship, active: true}
 
   before :each do
     sign_in instance_double(AdminUser)
   end
 
   context "#inactivate" do
+    let(:sponsorship_inactivator) {instance_double InactivateSponsorship}
+    let(:date) {"2015-01-01"}
+
+    before :each do
+      expect(Sponsorship).to receive(:find).with(sponsorship.id.to_s).and_return(sponsorship)
+      expect(InactivateSponsorship).to receive(:new)
+        .with(sponsorship: sponsorship, end_date: date)
+        .and_return(sponsorship_inactivator)
+    end
+
     specify "successful" do
-      expect(Sponsorship).to receive(:find).and_return(sponsorship)
-      expect(sponsorship).to receive(:update!)
-      put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
+      expect(sponsorship_inactivator).to receive(:call).and_return(true)
+      put :inactivate, id: sponsorship.id, sponsorship: {end_date: date}
 
       expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
       expect(flash[:success]).to_not be_nil
     end
 
     specify "unsuccessful" do
-      expect(Sponsorship).to receive(:find).and_return(sponsorship)
-      expect(sponsorship).to receive(:update!).and_raise
-      put :inactivate, id: sponsorship.id, sponsorship: {end_date: Date.current}
+      expect(sponsorship_inactivator).to receive(:call).and_return(false)
+      expect(sponsorship_inactivator).to receive(:error_msg).and_return("error mess")
+      put :inactivate, id: sponsorship.id, sponsorship: {end_date: date}
 
       expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
-      expect(flash[:error]).to_not be_nil
+      expect(flash[:error]).to eq "error mess"
     end
   end
 
   context "#destroy" do
+    let(:sponsorship_destructor) {instance_double DestroySponsorship}
+
+    before :each do
+      expect(Sponsorship).to receive(:find).with(sponsorship.id.to_s).and_return(sponsorship)
+      expect(DestroySponsorship).to receive(:new)
+        .with(sponsorship).and_return(sponsorship_destructor)
+    end
+
     specify "successful" do
-      expect(Sponsorship).to receive(:find).and_return(sponsorship)
-      expect(sponsorship).to receive(:destroy!)
+      expect(sponsorship_destructor).to receive(:call).and_return(true)
       delete :destroy, id: sponsorship.id
 
       expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
@@ -38,12 +54,12 @@ RSpec.describe Hq::SponsorshipsController, type: :controller do
     end
 
     specify "unsuccessful" do
-      expect(Sponsorship).to receive(:find).and_return(sponsorship)
-      expect(sponsorship).to receive(:destroy!).and_raise
+      expect(sponsorship_destructor).to receive(:call).and_return(false)
+      expect(sponsorship_destructor).to receive(:error_msg).and_return("error mess")
       delete :destroy, id: sponsorship.id
 
       expect(response).to redirect_to hq_sponsor_path(sponsorship.sponsor)
-      expect(flash[:error]).to_not be_nil
+      expect(flash[:error]).to eq "error mess"
     end
   end
 end

--- a/spec/views/hq/sponsors/_sponsorships_active_spec.rb
+++ b/spec/views/hq/sponsors/_sponsorships_active_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe 'hq/sponsors/_sponsorships_active.html.haml', type: :view do
     end
 
     it "should have End Sponsorship form" do
-      expect(rendered).to have_button "End Sponsorship"
+      expect(rendered).to have_button "End Sponsorship", inactivate_hq_sponsorship_path(sponsorships_active.first)
       expect(rendered).to have_css("input[type='text'][value='#{Date.current}']")
     end
 
     it "should have delete (X) button" do
       sponsorships_active.each do |sa|
-        expect(rendered).to have_link "X", hq_sponsor_sponsorship_path(sa.sponsor,sa)
+        expect(rendered).to have_link "X", hq_sponsorship_path(sa)
       end
     end
   end

--- a/spec/views/hq/sponsors/_sponsorships_active_spec.rb
+++ b/spec/views/hq/sponsors/_sponsorships_active_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'hq/sponsors/_sponsorships_active.html.haml', type: :view do
-  let(:orphan) {build_stubbed :orphan}
-  let(:sponsorships_active) {(1..3).map {build_stubbed :sponsorship, active: true, orphan: orphan}}
+  let(:sponsorships_active) {build_stubbed_list :sponsorship, 3, active:true, orphan: build_stubbed(:orphan)}
 
   describe "active sponsorships exist" do
     before :each do
@@ -15,7 +14,7 @@ RSpec.describe 'hq/sponsors/_sponsorships_active.html.haml', type: :view do
 
     it "should show sponsorships and linked orphans details" do
       sponsorships_active.each do |sa|
-        expect(rendered).to have_link(sa.orphan.name, hq_orphan_path(sa.orphan_id))
+        expect(rendered).to have_link(sa.orphan.name, hq_orphan_path(sa.orphan))
         expect(rendered).to have_text(sa.orphan.date_of_birth)
         expect(rendered).to have_text(sa.orphan.gender)
         expect(rendered).to have_text(sa.start_date)
@@ -27,14 +26,14 @@ RSpec.describe 'hq/sponsors/_sponsorships_active.html.haml', type: :view do
       expect(rendered).to have_css("input[type='text'][value='#{Date.current}']")
     end
 
-    it "should have Delete button" do
+    it "should have delete (X) button" do
       sponsorships_active.each do |sa|
-        expect(rendered).to have_link "Delete", hq_sponsor_sponsorship_path(sa.sponsor_id,sa)
+        expect(rendered).to have_link "X", hq_sponsor_sponsorship_path(sa.sponsor,sa)
       end
     end
   end
 
-  describe "active sponsorships does not exist" do
+  describe "active sponsorships do not exist" do
     before :each do
       render :partial => 'hq/sponsors/sponsorships_active.html.haml', :locals => {sponsorships: []}
     end

--- a/spec/views/hq/sponsors/_sponsorships_active_spec.rb
+++ b/spec/views/hq/sponsors/_sponsorships_active_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'hq/sponsors/_sponsorships_active.html.haml', type: :view do
+  let(:orphan) {build_stubbed :orphan}
+  let(:sponsorships_active) {(1..3).map {build_stubbed :sponsorship, active: true, orphan: orphan}}
+
+  describe "active sponsorships exist" do
+    before :each do
+      render :partial => 'hq/sponsors/sponsorships_active.html.haml', :locals => {sponsorships: sponsorships_active}
+    end
+
+    it "should show table title" do
+      expect(rendered).to have_text "3 currently sponsored orphans"
+    end
+
+    it "should show sponsorships and linked orphans details" do
+      sponsorships_active.each do |sa|
+        expect(rendered).to have_link(sa.orphan.name, hq_orphan_path(sa.orphan_id))
+        expect(rendered).to have_text(sa.orphan.date_of_birth)
+        expect(rendered).to have_text(sa.orphan.gender)
+        expect(rendered).to have_text(sa.start_date)
+      end
+    end
+
+    it "should have End Sponsorship form" do
+      expect(rendered).to have_button "End Sponsorship"
+      expect(rendered).to have_css("input[type='text'][value='#{Date.current}']")
+    end
+
+    it "should have Delete button" do
+      sponsorships_active.each do |sa|
+        expect(rendered).to have_link "Delete", hq_sponsor_sponsorship_path(sa.sponsor_id,sa)
+      end
+    end
+  end
+
+  describe "active sponsorships does not exist" do
+    before :each do
+      render :partial => 'hq/sponsors/sponsorships_active.html.haml', :locals => {sponsorships: []}
+    end
+
+    it "should show message" do
+      expect(rendered).to have_text "No currently sponsored orphans"
+    end
+  end
+
+end

--- a/spec/views/hq/sponsors/_sponsorships_inactive_spec.rb
+++ b/spec/views/hq/sponsors/_sponsorships_inactive_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'hq/sponsors/_sponsorships_inactive.html.haml', type: :view do
-  let(:orphan) {build_stubbed :orphan}
-  let(:sponsorships_inactive) {(1..2).map {build_stubbed :sponsorship, active: false, orphan: orphan}}
+  let(:sponsorships_inactive) {build_stubbed_list :sponsorship, 2, active: false, orphan: build_stubbed(:orphan)}
 
   describe "inactive sponsorships exist" do
     before :each do
@@ -15,7 +14,7 @@ RSpec.describe 'hq/sponsors/_sponsorships_inactive.html.haml', type: :view do
 
     it "should show sponsorships and linked orphans details" do
       sponsorships_inactive.each do |sa|
-        expect(rendered).to have_link(sa.orphan.name, hq_orphan_path(sa.orphan_id))
+        expect(rendered).to have_link(sa.orphan.name, hq_orphan_path(sa.orphan))
         expect(rendered).to have_text(sa.orphan.date_of_birth)
         expect(rendered).to have_text(sa.orphan.gender)
         expect(rendered).to have_text(sa.start_date)
@@ -24,7 +23,7 @@ RSpec.describe 'hq/sponsors/_sponsorships_inactive.html.haml', type: :view do
     end
   end
 
-  describe "active sponsorships exist" do
+  describe "inactive sponsorships do not exist" do
     before :each do
       render :partial => 'hq/sponsors/sponsorships_inactive.html.haml', :locals => {sponsorships: []}
     end

--- a/spec/views/hq/sponsors/_sponsorships_inactive_spec.rb
+++ b/spec/views/hq/sponsors/_sponsorships_inactive_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'hq/sponsors/_sponsorships_inactive.html.haml', type: :view do
+  let(:orphan) {build_stubbed :orphan}
+  let(:sponsorships_inactive) {(1..2).map {build_stubbed :sponsorship, active: false, orphan: orphan}}
+
+  describe "inactive sponsorships exist" do
+    before :each do
+      render :partial => 'hq/sponsors/sponsorships_inactive.html.haml', :locals => {sponsorships: sponsorships_inactive}
+    end
+
+    it "should show table title" do
+      expect(rendered).to have_text "2 previously sponsored orphans"
+    end
+
+    it "should show sponsorships and linked orphans details" do
+      sponsorships_inactive.each do |sa|
+        expect(rendered).to have_link(sa.orphan.name, hq_orphan_path(sa.orphan_id))
+        expect(rendered).to have_text(sa.orphan.date_of_birth)
+        expect(rendered).to have_text(sa.orphan.gender)
+        expect(rendered).to have_text(sa.start_date)
+        expect(rendered).to have_text(sa.end_date)
+      end
+    end
+  end
+
+  describe "active sponsorships exist" do
+    before :each do
+      render :partial => 'hq/sponsors/sponsorships_inactive.html.haml', :locals => {sponsorships: []}
+    end
+
+    it "should show message" do
+      expect(rendered).to have_text "No previously sponsored orphans"
+    end
+  end
+
+end

--- a/spec/views/hq/sponsors/show_spec.rb
+++ b/spec/views/hq/sponsors/show_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "hq/sponsors/show.html.haml", type: :view do
   describe 'the sponsor exists' do
     before :each do
       assign(:sponsor, sponsor)
+      assign(:sponsorships_active, [])
+      assign(:sponsorships_inactive, [])
       render
     end
 
@@ -20,6 +22,11 @@ RSpec.describe "hq/sponsors/show.html.haml", type: :view do
 
     it 'should have a Link to Orphan button' do
       expect(rendered).to have_link('Link to Orphan')
+    end
+
+    it 'should delegate to partials' do
+      expect(view).to render_template partial: 'hq/sponsors/sponsorships_active.html.haml', locals: {sponsorships: []}
+      expect(view).to render_template partial: 'hq/sponsors/sponsorships_inactive.html.haml', locals: {sponsorships: []}
     end
   end
 

--- a/spec/views/hq/sponsors/show_spec.rb
+++ b/spec/views/hq/sponsors/show_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "hq/sponsors/show.html.haml", type: :view do
   describe 'the sponsor exists' do
     before :each do
       assign(:sponsor, sponsor)
-      assign(:sponsorships_active, [])
-      assign(:sponsorships_inactive, [])
+      assign(:sponsorships_active, Sponsorship.none)
+      assign(:sponsorships_inactive, Sponsorship.none)
       render
     end
 


### PR DESCRIPTION
Add "Sponsored Orphans" list to the sponsor show view
https://osraav.atlassian.net/browse/OSRA-392

- added 2 tables to the Sponsor#show view:
     - currently sponsored orphans (using a partial)
     - previously sponsored orphans (using a partial)
- added sponsorship routes for inactivate and destroy
- added Sponsorship#inactivate  controller action
- added Sponsorship#destroy  controller action
- added controller and view specs

Did not add integration tests.