### PR TITLE
OSRA-386 Show no. of sponsorships in sponsor index

### DIFF
--- a/app/admin/sponsor.rb
+++ b/app/admin/sponsor.rb
@@ -30,7 +30,13 @@ ActiveAdmin.register Sponsor do
     end
     column :status, sortable: :status_id
     column :start_date
-    column :request_fulfilled
+    column :request_fulfilled do |sponsor|
+      label = sponsor.request_fulfilled ? 'Yes' : 'No'
+      label << %Q%
+        (#{sponsor.active_sponsorship_count}/#{sponsor.requested_orphan_count})
+      %
+      status_tag(sponsor.request_fulfilled ? 'yes' : 'no', label: label)
+    end
     column :sponsor_type
     column :country do |_sponsor|
       en_ar_country(_sponsor.country)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,12 +17,12 @@ ActiveRecord::Schema.define(version: 20141229224941) do
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", force: :cascade do |t|
-    t.string   "namespace",     limit: 255
+    t.string   "namespace"
     t.text     "body"
-    t.string   "resource_id",   limit: 255, null: false
-    t.string   "resource_type", limit: 255, null: false
+    t.string   "resource_id",   null: false
+    t.string   "resource_type", null: false
     t.integer  "author_id"
-    t.string   "author_type",   limit: 255
+    t.string   "author_type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -33,10 +33,10 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer  "province_id"
-    t.string   "city",                       limit: 255
-    t.string   "neighborhood",               limit: 255
-    t.string   "street",                     limit: 255
-    t.string   "details",                    limit: 255
+    t.string   "city"
+    t.string   "neighborhood"
+    t.string   "street"
+    t.string   "details"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "orphan_original_address_id"
@@ -48,16 +48,16 @@ ActiveRecord::Schema.define(version: 20141229224941) do
   add_index "addresses", ["province_id"], name: "index_addresses_on_province_id", using: :btree
 
   create_table "admin_users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "", null: false
-    t.string   "encrypted_password",     limit: 255, default: "", null: false
-    t.string   "reset_password_token",   limit: 255
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",     limit: 255
-    t.string   "last_sign_in_ip",        limit: 255
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "branches", force: :cascade do |t|
     t.integer  "code"
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "organizations", force: :cascade do |t|
     t.integer  "code"
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -85,14 +85,14 @@ ActiveRecord::Schema.define(version: 20141229224941) do
   add_index "organizations", ["name"], name: "index_organizations_on_name", unique: true, using: :btree
 
   create_table "orphan_lists", force: :cascade do |t|
-    t.string   "osra_num",                 limit: 255
+    t.string   "osra_num"
     t.integer  "partner_id"
     t.integer  "orphan_count"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "sequential_id"
-    t.string   "spreadsheet_file_name",    limit: 255
-    t.string   "spreadsheet_content_type", limit: 255
+    t.string   "spreadsheet_file_name"
+    t.string   "spreadsheet_content_type"
     t.integer  "spreadsheet_file_size"
     t.datetime "spreadsheet_updated_at"
   end
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "orphan_sponsorship_statuses", force: :cascade do |t|
     t.integer  "code"
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -113,48 +113,48 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "orphan_statuses", force: :cascade do |t|
     t.integer "code"
-    t.string  "name", limit: 255
+    t.string  "name"
   end
 
   add_index "orphan_statuses", ["code"], name: "index_orphan_statuses_on_code", unique: true, using: :btree
   add_index "orphan_statuses", ["name"], name: "index_orphan_statuses_on_name", unique: true, using: :btree
 
   create_table "orphans", force: :cascade do |t|
-    t.string   "name",                            limit: 255
+    t.string   "name"
     t.boolean  "father_is_martyr"
-    t.string   "father_occupation",               limit: 255
-    t.string   "father_place_of_death",           limit: 255
-    t.string   "father_cause_of_death",           limit: 255
+    t.string   "father_occupation"
+    t.string   "father_place_of_death"
+    t.string   "father_cause_of_death"
     t.date     "father_date_of_death"
-    t.string   "mother_name",                     limit: 255
+    t.string   "mother_name"
     t.boolean  "mother_alive"
     t.date     "date_of_birth"
-    t.string   "gender",                          limit: 255
-    t.string   "health_status",                   limit: 255
-    t.string   "schooling_status",                limit: 255
+    t.string   "gender"
+    t.string   "health_status"
+    t.string   "schooling_status"
     t.boolean  "goes_to_school"
-    t.string   "guardian_name",                   limit: 255
-    t.string   "guardian_relationship",           limit: 255
+    t.string   "guardian_name"
+    t.string   "guardian_relationship"
     t.integer  "guardian_id_num"
-    t.string   "contact_number",                  limit: 255
-    t.string   "alt_contact_number",              limit: 255
+    t.string   "contact_number"
+    t.string   "alt_contact_number"
     t.boolean  "sponsored_by_another_org"
-    t.string   "another_org_sponsorship_details", limit: 255
+    t.string   "another_org_sponsorship_details"
     t.integer  "minor_siblings_count"
     t.integer  "sponsored_minor_siblings_count"
-    t.string   "comments",                        limit: 255
+    t.string   "comments"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "orphan_status_id"
     t.integer  "orphan_sponsorship_status_id"
-    t.string   "priority",                        limit: 255
+    t.string   "priority"
     t.integer  "sequential_id"
-    t.string   "osra_num",                        limit: 255
+    t.string   "osra_num"
     t.integer  "orphan_list_id"
     t.integer  "province_code"
     t.boolean  "father_alive"
-    t.string   "father_given_name",               limit: 255, null: false
-    t.string   "family_name",                     limit: 255, null: false
+    t.string   "father_given_name",               null: false
+    t.string   "family_name",                     null: false
   end
 
   add_index "orphans", ["orphan_list_id"], name: "index_orphans_on_orphan_list_id", using: :btree
@@ -165,15 +165,15 @@ ActiveRecord::Schema.define(version: 20141229224941) do
   add_index "orphans", ["sequential_id"], name: "index_orphans_on_sequential_id", using: :btree
 
   create_table "partners", force: :cascade do |t|
-    t.string   "name",            limit: 255
-    t.string   "region",          limit: 255
+    t.string   "name"
+    t.string   "region"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "contact_details", limit: 255
+    t.string   "contact_details"
     t.integer  "province_id"
     t.integer  "status_id"
     t.date     "start_date"
-    t.string   "osra_num",        limit: 255
+    t.string   "osra_num"
     t.integer  "sequential_id"
   end
 
@@ -184,8 +184,8 @@ ActiveRecord::Schema.define(version: 20141229224941) do
   add_index "partners", ["status_id"], name: "index_partners_on_status_id", using: :btree
 
   create_table "pending_orphan_lists", force: :cascade do |t|
-    t.string   "spreadsheet_file_name",    limit: 255
-    t.string   "spreadsheet_content_type", limit: 255
+    t.string   "spreadsheet_file_name"
+    t.string   "spreadsheet_content_type"
     t.integer  "spreadsheet_file_size"
     t.datetime "spreadsheet_updated_at"
     t.datetime "created_at"
@@ -194,49 +194,49 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "pending_orphans", force: :cascade do |t|
     t.integer "pending_orphan_list_id"
-    t.string  "name",                            limit: 255
-    t.string  "father_is_martyr",                limit: 255
-    t.string  "father_occupation",               limit: 255
-    t.string  "father_place_of_death",           limit: 255
-    t.string  "father_cause_of_death",           limit: 255
-    t.string  "father_date_of_death",            limit: 255
-    t.string  "mother_name",                     limit: 255
-    t.string  "mother_alive",                    limit: 255
-    t.string  "date_of_birth",                   limit: 255
-    t.string  "gender",                          limit: 255
-    t.string  "health_status",                   limit: 255
-    t.string  "schooling_status",                limit: 255
-    t.string  "goes_to_school",                  limit: 255
-    t.string  "guardian_name",                   limit: 255
-    t.string  "guardian_relationship",           limit: 255
-    t.string  "guardian_id_num",                 limit: 255
-    t.string  "original_address_province",       limit: 255
-    t.string  "original_address_city",           limit: 255
-    t.string  "original_address_neighborhood",   limit: 255
-    t.string  "original_address_street",         limit: 255
-    t.string  "original_address_details",        limit: 255
-    t.string  "current_address_province",        limit: 255
-    t.string  "current_address_city",            limit: 255
-    t.string  "current_address_neighborhood",    limit: 255
-    t.string  "current_address_street",          limit: 255
-    t.string  "current_address_details",         limit: 255
-    t.string  "contact_number",                  limit: 255
-    t.string  "alt_contact_number",              limit: 255
-    t.string  "sponsored_by_another_org",        limit: 255
-    t.string  "another_org_sponsorship_details", limit: 255
-    t.string  "minor_siblings_count",            limit: 255
-    t.string  "sponsored_minor_siblings_count",  limit: 255
-    t.string  "comments",                        limit: 255
+    t.string  "name"
+    t.string  "father_is_martyr"
+    t.string  "father_occupation"
+    t.string  "father_place_of_death"
+    t.string  "father_cause_of_death"
+    t.string  "father_date_of_death"
+    t.string  "mother_name"
+    t.string  "mother_alive"
+    t.string  "date_of_birth"
+    t.string  "gender"
+    t.string  "health_status"
+    t.string  "schooling_status"
+    t.string  "goes_to_school"
+    t.string  "guardian_name"
+    t.string  "guardian_relationship"
+    t.string  "guardian_id_num"
+    t.string  "original_address_province"
+    t.string  "original_address_city"
+    t.string  "original_address_neighborhood"
+    t.string  "original_address_street"
+    t.string  "original_address_details"
+    t.string  "current_address_province"
+    t.string  "current_address_city"
+    t.string  "current_address_neighborhood"
+    t.string  "current_address_street"
+    t.string  "current_address_details"
+    t.string  "contact_number"
+    t.string  "alt_contact_number"
+    t.string  "sponsored_by_another_org"
+    t.string  "another_org_sponsorship_details"
+    t.string  "minor_siblings_count"
+    t.string  "sponsored_minor_siblings_count"
+    t.string  "comments"
     t.boolean "father_alive"
-    t.string  "father_given_name",               limit: 255
-    t.string  "family_name",                     limit: 255
+    t.string  "father_given_name"
+    t.string  "family_name"
   end
 
   add_index "pending_orphans", ["pending_orphan_list_id"], name: "index_pending_orphans_on_pending_orphan_list_id", using: :btree
 
   create_table "provinces", force: :cascade do |t|
     t.integer  "code"
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -246,36 +246,36 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "sponsor_types", force: :cascade do |t|
     t.integer "code"
-    t.string  "name", limit: 255
+    t.string  "name"
   end
 
   add_index "sponsor_types", ["code"], name: "index_sponsor_types_on_code", unique: true, using: :btree
   add_index "sponsor_types", ["name"], name: "index_sponsor_types_on_name", unique: true, using: :btree
 
   create_table "sponsors", force: :cascade do |t|
-    t.string   "name",                     limit: 255
-    t.string   "address",                  limit: 255
-    t.string   "country",                  limit: 255
-    t.string   "email",                    limit: 255
-    t.string   "contact1",                 limit: 255
-    t.string   "contact2",                 limit: 255
-    t.string   "additional_info",          limit: 255
+    t.string   "name"
+    t.string   "address"
+    t.string   "country"
+    t.string   "email"
+    t.string   "contact1"
+    t.string   "contact2"
+    t.string   "additional_info"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "status_id"
     t.date     "start_date"
     t.integer  "sponsor_type_id"
-    t.string   "gender",                   limit: 255
+    t.string   "gender"
     t.integer  "branch_id"
     t.integer  "organization_id"
-    t.string   "osra_num",                 limit: 255
+    t.string   "osra_num"
     t.integer  "sequential_id"
     t.integer  "requested_orphan_count"
-    t.boolean  "request_fulfilled",                    default: false, null: false
+    t.boolean  "request_fulfilled",        default: false, null: false
     t.integer  "agent_id"
-    t.string   "city",                     limit: 255
-    t.string   "payment_plan",             limit: 255, default: "",    null: false
-    t.integer  "active_sponsorship_count",             default: 0
+    t.string   "city"
+    t.string   "payment_plan",             default: "",    null: false
+    t.integer  "active_sponsorship_count", default: 0
   end
 
   add_index "sponsors", ["agent_id"], name: "index_sponsors_on_agent_id", using: :btree
@@ -303,17 +303,17 @@ ActiveRecord::Schema.define(version: 20141229224941) do
 
   create_table "statuses", force: :cascade do |t|
     t.integer "code"
-    t.string  "name", limit: 255
+    t.string  "name"
   end
 
   add_index "statuses", ["code"], name: "index_statuses_on_code", unique: true, using: :btree
   add_index "statuses", ["name"], name: "index_statuses_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",      limit: 255
+    t.string   "email"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "user_name",  limit: 255
+    t.string   "user_name"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION

![screenshot](https://cloud.githubusercontent.com/assets/5029403/6594096/de9da17a-c7e6-11e4-9259-43eaeaa4bdef.png)
https://osraav.atlassian.net/browse/OSRA-386

In sponsor index view, in addition to displaying 'Yes'/'No' in the 'Request
fulfilled' column, also show the number of current sponsorships out of the
total requested. e.g. 'Yes (2/2)' or 'No (1/3)'.

(This probably warrants a view spec, but since those are not an option under AA, I don't want to write a heavy-weight feature. Whoever ports this to HQ should test it, though.)

_db schema updates are only due to resetting the database, there are no
changes there pertinent to the PR's functionality._