### PR TITLE
Osra 355 v2 highlight mandatory form fields

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,5 +1,3 @@
- @import "bootstrap-sprockets";
- @import "bootstrap";
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.
@@ -10,13 +8,5 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
- *= require_self
- *= require_tree .
  */
-
- // To match the whole width space
- nav.osra-nav-header {
-   width: auto;
-   margin-left: -15px;
-   margin-right: -15px;
- }
+@import "hq";

--- a/app/assets/stylesheets/hq.scss
+++ b/app/assets/stylesheets/hq.scss
@@ -1,3 +1,13 @@
+@import "bootstrap-sprockets";
+@import "bootstrap";
+
+// To match the whole width space
+nav.osra-nav-header {
+  width: auto;
+  margin-left: -15px;
+  margin-right: -15px;
+}
+
 .no-horiz-padding {
   padding-left: 0px;
   padding-right: 0px;
@@ -21,4 +31,9 @@ ul.nav li a {
     width:calc(100% - 80px);
     float:left;
   }
+}
+
+.required_field::after {
+  content: " (required)";
+  @extend .text-danger;
 }

--- a/app/helpers/osra_form_builder.rb
+++ b/app/helpers/osra_form_builder.rb
@@ -1,0 +1,20 @@
+class OsraFormBuilder < ActionView::Helpers::FormBuilder
+  def label_for_field(method, text = nil, options = {}, &block)
+    required_class = { :class => 'required_field' }
+
+    if presence_validated? method
+      options.merge!(required_class) { |_, va, vb| "#{va} #{vb}" }
+    end
+
+    @template.label(@object_name, method, text,
+                    objectify_options(options), &block)
+  end
+
+  private
+
+  def presence_validated?(attr)
+    attr_validators = object.class.validators_on(attr).map(&:class)
+
+    (PRESENCE_VALIDATORS & attr_validators).present?
+  end
+end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -8,7 +8,8 @@ class Partner < ActiveRecord::Base
   before_create :generate_osra_num
 
   validates :name, presence: true, uniqueness: true
-  validates :province, presence: true
+  validates :province_id, presence: true
+  validates :status_id, presence: true
   validates :start_date, valid_date_presence: true,
                          date_not_in_future: true,
                          date_beyond_osra_establishment: true

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -26,7 +26,8 @@ class Sponsor < ActiveRecord::Base
                          message: 'Please enter city name below. &darr;' }
   validates :request_fulfilled, inclusion: { in: [true, false] }
   validates :sponsor_type, presence: true
-  validates :gender, inclusion: { in: Settings.lookup.gender }
+  validates :status_id, presence: true
+  validates :gender, inclusion: { in: Settings.lookup.gender }, presence: true
   validates :payment_plan, allow_nil: false, allow_blank: true, inclusion: { in: PAYMENT_PLANS }
   validates :start_date, valid_date_presence: true,
                          date_beyond_osra_establishment: true,

--- a/app/views/hq/orphans/_form.html.erb
+++ b/app/views/hq/orphans/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:hq, orphan] do |f| %>
+<%= form_for [:hq, orphan], :builder => OsraFormBuilder do |f| %>
   <%= render 'shared/errors', object: f.object %>
   <div class="panel panel-default">
     <div class="panel-heading">
@@ -6,50 +6,50 @@
     </div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label :name %>
+        <%= f.label_for_field :name %>
         <%= f.text_field :name, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :date_of_birth %>
+        <%= f.label_for_field :date_of_birth %>
         <%= f.text_field :date_of_birth, class: "form-control date-picker", value: orphan.date_of_birth %>
       </div>
       <div class="form-group">
-        <%= f.label :gender %>
+        <%= f.label_for_field :gender %>
         <%= f.select :gender,
           Settings.lookup.gender, {}, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :health_status %>
+        <%= f.label_for_field :health_status %>
         <%= f.text_field :health_status, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :schooling_status %>
+        <%= f.label_for_field :schooling_status %>
         <%= f.text_field :schooling_status, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :goes_to_school %>
+        <%= f.label_for_field :goes_to_school %>
         <%= f.check_box :goes_to_school %>
       </div>
       <div class='form-group'>
-        <%= f.label :status %>
+        <%= f.label_for_field :status %>
         <%= f.select :status, statuses, {}, class: 'form-control' %>
       </div>
       <div class="form-group">
-        <%= f.label :sponsorship_status %>
+        <%= f.label_for_field :sponsorship_status %>
         <%= f.select :sponsorship_status, sponsorship_statuses, {},
           class: 'form-control', disabled: true %>
       </div>
       <div class="form-group">
-        <%= f.label :priority %>
+        <%= f.label_for_field :priority %>
         <%= f.select :priority,
           %w(Normal High), {}, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :created_at, 'Record imported on' %>
+        <%= f.label_for_field :created_at, 'Record imported on' %>
         <%= f.text_field :created_at, class: "form-control date-picker", value: orphan.created_at, disabled: "true" %>
       </div>
       <div class="form-group">
-        <%= f.label :updated_at, 'Record last updated on' %>
+        <%= f.label_for_field :updated_at, 'Record last updated on' %>
         <%= f.text_field :updated_at, class: "form-control date-picker", value: orphan.updated_at, disabled: "true" %>
       </div>
     </div>
@@ -60,43 +60,43 @@
     </div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label :father_given_name %>
+        <%= f.label_for_field :father_given_name %>
         <%= f.text_field :father_given_name, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :family_name %>
+        <%= f.label_for_field :family_name %>
         <%= f.text_field :family_name, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :father_deceased %>
+        <%= f.label_for_field :father_deceased %>
         <%= f.check_box :father_deceased %>
       </div>
       <div class="form-group">
-        <%= f.label :mother_name %>
+        <%= f.label_for_field :mother_name %>
         <%= f.text_field :mother_name, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :mother_alive %>
+        <%= f.label_for_field :mother_alive %>
         <%= f.check_box :mother_alive %>
       </div>
       <div class="form-group">
-        <%= f.label :father_is_martyr %>
+        <%= f.label_for_field :father_is_martyr %>
         <%= f.check_box :father_is_martyr %>
       </div>
       <div class="form-group">
-        <%= f.label :father_occupation %>
+        <%= f.label_for_field :father_occupation %>
         <%= f.text_field :father_occupation, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :father_place_of_death %>
+        <%= f.label_for_field :father_place_of_death %>
         <%= f.text_field :father_place_of_death, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :father_cause_of_death %>
+        <%= f.label_for_field :father_cause_of_death %>
         <%= f.text_field :father_cause_of_death, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :father_date_of_death %>
+        <%= f.label_for_field :father_date_of_death %>
         <%= f.text_field :father_date_of_death, class: "form-control date-picker", value: orphan.father_date_of_death %>
       </div>
     </div>
@@ -107,23 +107,23 @@
     </div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label :guardian_name %>
+        <%= f.label_for_field :guardian_name %>
         <%= f.text_field :guardian_name, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :guardian_relationship %>
+        <%= f.label_for_field :guardian_relationship %>
         <%= f.text_field :guardian_relationship, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :guardian_id_num %>
+        <%= f.label_for_field :guardian_id_num %>
         <%= f.text_field :guardian_id_num, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :contact_number %>
+        <%= f.label_for_field :contact_number %>
         <%= f.text_field :contact_number, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :alt_contact_number %>
+        <%= f.label_for_field :alt_contact_number %>
         <%= f.text_field :alt_contact_number, class: "form-control" %>
       </div>
     </div>
@@ -135,24 +135,24 @@
       <%= f.fields_for :original_address do |b| %>
         <div class="panel-body">
           <div class="form-group">
-            <%= b.label :city %>
+            <%= b.label_for_field :city %>
             <%= b.text_field :city, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= b.label :province %>
+            <%= b.label_for_field :province %>
             <%= b.collection_select :province_id,
               provinces, :id, :name, {},  {class: "form-control"} %>
           </div>
           <div class="form-group">
-            <%= b.label :neighborhood %>
+            <%= b.label_for_field :neighborhood %>
             <%= b.text_field :neighborhood, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= b.label :street %>
+            <%= b.label_for_field :street %>
             <%= b.text_field :street, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= b.label :details%>
+            <%= b.label_for_field :details%>
             <%= b.text_field :details, class: "form-control" %>
           </div>
         </div>
@@ -165,24 +165,24 @@
       <%= f.fields_for :current_address do |b| %>
         <div class="panel-body">
           <div class="form-group">
-            <%= b.label :city %>
+            <%= b.label_for_field :city %>
             <%= b.text_field :city, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= b.label :province %>
+            <%= b.label_for_field :province %>
             <%= b.collection_select :province_id,
               provinces, :id, :name, {},  {class: "form-control"} %>
           </div>
           <div class="form-group">
-            <%= b.label :neighborhood %>
+            <%= b.label_for_field :neighborhood %>
             <%= b.text_field :neighborhood, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= b.label :street %>
+            <%= b.label_for_field :street %>
             <%= b.text_field :street, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= b.label :details%>
+            <%= b.label_for_field :details%>
             <%= b.text_field :details, class: "form-control" %>
           </div>
         </div>
@@ -194,19 +194,19 @@
     </div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label :sponsored_by_another_org %>
+        <%= f.label_for_field :sponsored_by_another_org %>
         <%= f.check_box :sponsored_by_another_org %>
       </div>
       <div class="form-group">
-        <%= f.label :minor_siblings_count %>
+        <%= f.label_for_field :minor_siblings_count %>
         <%= f.text_field :minor_siblings_count, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :sponsored_minor_siblings_count %>
+        <%= f.label_for_field :sponsored_minor_siblings_count %>
         <%= f.text_field :sponsored_minor_siblings_count, class: "form-control" %>
       </div>
       <div class="form-group">
-        <%= f.label :comments %>
+        <%= f.label_for_field :comments %>
         <%= f.text_field :comments, class: "form-control" %>
       </div>
     </div>

--- a/app/views/hq/partners/_form.html.erb
+++ b/app/views/hq/partners/_form.html.erb
@@ -1,29 +1,29 @@
-<%= form_for [:hq, @partner] do |f| %>
+<%= form_for [:hq, @partner], :builder => OsraFormBuilder do |f| %>
   <%= render 'shared/errors', object: f.object %>
   <div class="form-group">
-    <%= f.label :name %>
+    <%= f.label_for_field :name %>
     <%= f.text_field :name, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :region %>
+    <%= f.label_for_field :region %>
     <%= f.text_field :region, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :contact_details %>
+    <%= f.label_for_field :contact_details %>
     <%= f.text_field :contact_details, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :province_id %>
+    <%= f.label_for_field :province_id %>
     <%= f.collection_select :province_id,
      @provinces, :id, :name , {},  class: "form-control", disabled: !f.object.new_record? %>
   </div>
   <div class="form-group">
-    <%= f.label :status_id %>
+    <%= f.label_for_field :status_id %>
     <%= f.collection_select :status_id,
       @statuses, :id, :name, {}, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :start_date %>
+    <%= f.label_for_field :start_date %>
     <%= f.text_field :start_date, class: "form-control date-picker" %>
   </div>
   <div class="form-group">

--- a/app/views/hq/sponsors/_form.html.haml
+++ b/app/views/hq/sponsors/_form.html.haml
@@ -1,55 +1,55 @@
-= form_for [:hq, sponsor] do |f|
+= form_for [:hq, sponsor], :builder => OsraFormBuilder do |f|
   = render 'shared/errors', object: f.object
 
   .form-group
-    = f.label :name
+    = f.label_for_field :name
     = f.text_field :name, class: "form-control"
 
   .form-group
-    = f.label :status_id
+    = f.label_for_field :status_id
     = f.collection_select :status_id, statuses, :id, :name, {},
           class: "form-control"
 
   .form-group
-    = f.label :gender
+    = f.label_for_field :gender
     = f.select :gender, Settings.lookup.gender, {}, class: "form-control"
 
   .form-group
-    = f.label :start_date
+    = f.label_for_field :start_date
     = f.text_field :start_date, class: "form-control date-picker"
 
   .form-group
-    = f.label :requested_orphan_count
+    = f.label_for_field :requested_orphan_count
     = f.text_field :requested_orphan_count, class: "form-control"
 
   - if !f.object.new_record?
     .form-group
-      = f.label :request_fulfilled
+      = f.label_for_field :request_fulfilled
       = f.check_box :request_fulfilled,
           {disabled: !f.object.new_record?, class: "checkbox"}
 
   .form-group
-    = f.label :sponsor_type
+    = f.label_for_field :sponsor_type
     = f.collection_select :sponsor_type_id, sponsor_types, :id, :name,
           {}, {class: "form-control", disabled: !f.object.new_record?}
 
   .form-group
-    = f.label :organization
+    = f.label_for_field :organization
     = f.collection_select :organization_id, organizations, :id, :name,
           {include_blank: true},  {class: "form-control", disabled: !f.object.new_record?}
 
   .form-group
-    = f.label :branch
+    = f.label_for_field :branch
     = f.collection_select :branch_id, branches, :id, :name,
           {include_blank: true},  {class: "form-control", disabled: !f.object.new_record?}
 
   .form-group
-    = f.label :payment_plan
+    = f.label_for_field :payment_plan
     = f.select :payment_plan, Sponsor::PAYMENT_PLANS,
           {include_blank: true}, class: "form-control"
 
   .form-group
-    = f.label :country
+    = f.label_for_field :country
     = country_select("sponsor", "country",
                      { format: :en_ar,
                        selected: f.object.country,
@@ -58,35 +58,35 @@
                      { class: "form-control" })
 
   .form-group
-    = f.label :city
+    = f.label_for_field :city
     = f.select :city, cities, {}, class: "form-control"
 
   .form-group
-    = f.label :new_city_name
+    = f.label_for_field :new_city_name
     = f.text_field :new_city_name, class: "form-control"
 
   .form-group
-    = f.label :address
+    = f.label_for_field :address
     = f.text_field :address, class: "form-control"
 
   .form-group
-    = f.label :email
+    = f.label_for_field :email
     = f.text_field :email, {class: "form-control", type: "email"}
 
   .form-group
-    = f.label :contact1
+    = f.label_for_field :contact1
     = f.text_field :contact1, class: "form-control"
 
   .form-group
-    = f.label :contact2
+    = f.label_for_field :contact2
     = f.text_field :contact2, class: "form-control"
 
   .form-group
-    = f.label :additional_info
+    = f.label_for_field :additional_info
     = f.text_field :additional_info, class: "form-control"
 
   .form-group
-    = f.label :agent
+    = f.label_for_field :agent
     = f.select :agent_id, User.pluck(:user_name, :id),
           {include_blank: true}, class: "form-control"
 

--- a/app/views/hq/users/_form.html.erb
+++ b/app/views/hq/users/_form.html.erb
@@ -1,11 +1,11 @@
-<%= form_for [:hq, @user] do |f| %>
+<%= form_for [:hq, @user], :builder => OsraFormBuilder do |f| %>
   <%= render 'shared/errors', object: f.object %>
   <div class="form-group">
-    <%= f.label :user_name %>
+    <%= f.label_for_field :user_name %>
     <%= f.text_field :user_name, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :email %>
+    <%= f.label_for_field :email %>
     <%= f.text_field :email, class: "form-control" %>
   </div>
   <div class="form-group">

--- a/config/initializers/osra_constants.rb
+++ b/config/initializers/osra_constants.rb
@@ -1,0 +1,2 @@
+PRESENCE_VALIDATORS = [ActiveRecord::Validations::PresenceValidator,
+                       ValidDatePresenceValidator]

--- a/spec/custom_matchers/optional_form_fields_matcher_spec.rb
+++ b/spec/custom_matchers/optional_form_fields_matcher_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'optional_form_fields_matcher' do
+  let(:test_class) do
+    Class.new do
+      include ActiveRecord::Validations
+
+      attr_accessor :presence_validated_attr,
+        :non_validated_attr,
+        :date_validated_attr
+
+      validates :validated_attr, presence: true
+      validates :date_validated_attr, valid_date_presence: true
+      validates :non_validated_attr, inclusion: { in: [0, 1] }
+
+      def attributes
+        {
+          :validated_attr => nil,
+          :date_validated_attr => nil,
+          :non_validated_attr => nil
+        }
+      end
+
+      def self.name
+        "TestClass"
+      end
+    end
+  end
+
+  describe 'required_fields matcher' do
+    specify 'works when form is correct' do
+      correct_form = <<-END
+        <label class="required_field" for="test_class_validated_attr"></label>
+        <label class="another_class" for="test_class_non_validated_attr"></label>
+        <label class="required_field" for="test_class_date_validated_attr"></label>
+      END
+
+      expect(correct_form).not_to mark_optional_fields_for test_class
+    end
+
+    specify 'works when form is incorrect' do
+      incorrect_form = <<-END
+        <label class="required_field" for="test_class_validated_attr"></label>
+        <label class="required_field" for="test_class_non_validated_attr"></label>
+        <label class="another_class" for="test_class_date_validated_attr"></label>
+      END
+
+      expect(incorrect_form).to mark_optional_fields_for test_class
+    end
+  end
+end

--- a/spec/custom_matchers/required_form_fields_matcher_spec.rb
+++ b/spec/custom_matchers/required_form_fields_matcher_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'required_form_fields_matcher' do
+  let(:test_class) do
+    Class.new do
+      include ActiveRecord::Validations
+
+      attr_accessor :presence_validated_attr,
+        :non_validated_attr,
+        :date_validated_attr
+
+      validates :validated_attr, presence: true
+      validates :date_validated_attr, valid_date_presence: true
+      validates :non_validated_attr, inclusion: { in: [0, 1] }
+
+      def attributes
+        {
+          :validated_attr => nil,
+          :date_validated_attr => nil,
+          :non_validated_attr => nil
+        }
+      end
+
+      def self.name
+        "TestClass"
+      end
+    end
+  end
+
+  describe 'required_fields matcher' do
+    specify 'works when form is correct' do
+      correct_form = <<-END
+        <label class="required_field" for="test_class_validated_attr"></label>
+        <label class="another_class" for="test_class_non_validated_attr"></label>
+        <label class="required_field" for="test_class_date_validated_attr"></label>
+      END
+
+      expect(correct_form).to mark_required_fields_for test_class
+    end
+
+    specify 'works when form is incorrect' do
+      incorrect_form = <<-END
+        <label class="another_class" for="test_class_validated_attr"></label>
+        <label class="another_class" for="test_class_non_validated_attr"></label>
+        <label class="required_field" for="test_class_date_validated_attr"></label>
+      END
+
+      expect(incorrect_form).not_to mark_required_fields_for test_class
+    end
+  end
+end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -13,7 +13,8 @@ describe Partner, type: :model do
     it { is_expected.to validate_uniqueness_of :name }
   end
 
-  it { is_expected.to validate_presence_of :province }
+  it { is_expected.to validate_presence_of :province_id }
+  it { is_expected.to validate_presence_of :status_id }
   it { is_expected.to belong_to :province }
   it { is_expected.to belong_to :status }
 

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -25,6 +25,8 @@ describe Sponsor, type: :model do
   it { is_expected.to validate_presence_of :sponsor_type }
   it { is_expected.to validate_presence_of :agent }
 
+  it { is_expected.to validate_presence_of :gender }
+  it { is_expected.to validate_presence_of :status_id }
   it { is_expected.to validate_inclusion_of(:gender).in_array Settings.lookup.gender }
   it { is_expected.to validate_inclusion_of(:payment_plan).in_array (Sponsor::PAYMENT_PLANS << '') }
   it { is_expected.to validate_inclusion_of(:country).in_array ISO3166::Country.countries.map { |c| c[1] } - ['IL'] }

--- a/spec/support/optional_form_fields_matcher.rb
+++ b/spec/support/optional_form_fields_matcher.rb
@@ -1,0 +1,41 @@
+RSpec::Matchers.define :mark_optional_fields_for do |object_class|
+
+  match do |form|
+    @form = form
+    @object_class = object_class
+    optional_attributes = attrs_without_presence_validation
+    form_does_not_mark_any_fields_for? optional_attributes
+  end
+
+  failure_message_when_negated do |form|
+    "expected form not to mark as required fields for #{fields_wrongly_marked}"
+  end
+
+  def attrs_without_presence_validation
+    @object_class.new.attributes.keys.reject do |attr|
+      (@object_class.validators_on(attr).map(&:class) & PRESENCE_VALIDATORS).present?
+    end
+  end
+
+  def form_does_not_mark_any_fields_for?(attributes)
+    @fields_not_marked_required = attributes.inject({}) do |h, attr|
+      required_label = %r{
+        label
+        \s
+        class=\"required_field\"
+        \s
+        for=\"#{@object_class.name.underscore}_#{attr}\"
+      }x
+
+      h[attr] = @form =~ required_label
+      h
+    end
+
+    @fields_not_marked_required.values.any?
+  end
+
+  def fields_wrongly_marked
+    @fields_not_marked_required.reject { |_, v| v.nil? }.keys.join(', ')
+  end
+end
+

--- a/spec/support/required_form_fields_matcher.rb
+++ b/spec/support/required_form_fields_matcher.rb
@@ -1,0 +1,40 @@
+RSpec::Matchers.define :mark_required_fields_for do |object_class|
+
+  match do |form|
+    @form = form
+    @object_class = object_class
+    required_attributes = attrs_with_presence_validation
+    form_marks_all_fields_for? required_attributes
+  end
+
+  failure_message do |form|
+    "expected form to mark as required fields for #{fields_with_missing_mark}"
+  end
+
+  def attrs_with_presence_validation
+    @object_class.new.attributes.keys.select do |attr|
+      (@object_class.validators_on(attr).map(&:class) & PRESENCE_VALIDATORS).present?
+    end
+  end
+
+  def form_marks_all_fields_for?(attributes)
+    @fields_marked_required = attributes.inject({}) do |h, attr|
+      required_label = %r{
+        label
+        \s
+        class=\"required_field\"
+        \s
+        for=\"#{@object_class.name.underscore}_#{attr}\"
+      }x
+
+      h[attr] = @form =~ required_label
+      h
+    end
+
+    @fields_marked_required.values.all?
+  end
+
+  def fields_with_missing_mark
+    @fields_marked_required.reject { |_, v| v }.keys.join(', ')
+  end
+end

--- a/spec/views/hq/orphans/_form_spec.rb
+++ b/spec/views/hq/orphans/_form_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'cgi'
 
 RSpec.describe "hq/orphans/_form.html.erb", type: :view do
 
@@ -107,6 +106,18 @@ RSpec.describe "hq/orphans/_form.html.erb", type: :view do
 
     #submit button
     expect(rendered).to have_selector("input[type='submit'][value='Update Orphan']")
+  end
+
+  describe 'required fields' do
+    before(:each) { render_orphan_form orphan_full }
+
+    it 'marks required fields' do
+      expect(rendered).to mark_required_fields_for Orphan
+    end
+
+    it 'does not mark optional' do
+      expect(rendered).not_to mark_optional_fields_for Orphan
+    end
   end
 end
 

--- a/spec/views/hq/partners/_form.html.erb_spec.rb
+++ b/spec/views/hq/partners/_form.html.erb_spec.rb
@@ -45,4 +45,16 @@ RSpec.describe "hq/partners/_form.html.erb", type: :view do
     expect(rendered).to have_field("Start date", with: partner.start_date.to_s)
     expect(rendered).to have_selector("input[type='submit'][value='Update Partner']")
   end
+
+  describe 'required fields' do
+    before(:each) { render }
+
+    it 'marks required fields' do
+      expect(rendered).to mark_required_fields_for Partner
+    end
+
+    it 'does not mark optional' do
+      expect(rendered).not_to mark_optional_fields_for Partner
+    end
+  end
 end

--- a/spec/views/hq/sponsors/_form_spec.rb
+++ b/spec/views/hq/sponsors/_form_spec.rb
@@ -111,6 +111,18 @@ RSpec.describe "hq/sponsors/_form.html.haml", type: :view do
         expect(rendered).to_not have_selector("select[id='sponsor_#{field}_id'][disabled]")
       end
     end
+
+    describe 'required fields' do
+      before(:each) { render_sponsor_form sponsor_full }
+
+      it 'marks required fields' do
+        expect(rendered).to mark_required_fields_for Sponsor
+      end
+
+      it 'does not mark optional' do
+        expect(rendered).not_to mark_optional_fields_for Sponsor
+      end
+    end
   end
 
 end

--- a/spec/views/hq/users/_form.html.erb_spec.rb
+++ b/spec/views/hq/users/_form.html.erb_spec.rb
@@ -27,4 +27,14 @@ describe "hq/users/_form.html.erb", type: :view do
     expect(rendered).to have_link('Cancel', href: 'some cancel url')
   end
 
+  describe 'required fields' do
+    it 'marks required fields' do
+      expect(rendered).to mark_required_fields_for User
+    end
+
+    it 'does not mark optional' do
+      expect(rendered).not_to mark_optional_fields_for User
+    end
+  end
+
 end


### PR DESCRIPTION
Alternative implementation to #361

https://osraav.atlassian.net/browse/OSRA-355

Subclass custom form builder from `ActionView::Helpers::FormBuilder` and define `label_for_field` method within it. The method checks whether the field's attribute has a presence validation and, if so, appends a `required_field` CSS class to the options before passing things along to the native FormBuilder's `label` method. CSS then appends " (required)" to the label.

 - both Rails' native presence validation and OSRA's custom `ValidDatePresence` validation used to determine required attributes
 - custom RSpec matchers to test that required fields are labeled and that optional fields are not
 - explicit presence validations added to several attributes to facilitate labeling of form fields
 - stylesheet reconfigured as per Bootstrap guidelines