### PR TITLE
OSRA-397 Sponsorship totals fix

### DIFF
--- a/app/helpers/sponsorship_totals_helper.rb
+++ b/app/helpers/sponsorship_totals_helper.rb
@@ -5,6 +5,6 @@ module SponsorshipTotalsHelper
   end
 
   def total_requested_sponsorships
-    Sponsor.pluck(:requested_orphan_count).sum
+    Sponsor.all_active.pluck(:requested_orphan_count).sum
   end
 end

--- a/spec/helpers/sponsorship_totals_helper_spec.rb
+++ b/spec/helpers/sponsorship_totals_helper_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe SponsorshipTotalsHelper, :type => :helper do
   end
 
   specify 'total_requested_sponsorships returns total of requested sponsorships' do
-    allow(Sponsor).to receive(:pluck).with(:requested_orphan_count).
+    sponsors = double
+    allow(Sponsor).to receive(:all_active).and_return sponsors
+    allow(sponsors).to receive(:pluck).with(:requested_orphan_count).
       and_return([1, 3, 5])
 
     expect(total_requested_sponsorships).to eq 9


### PR DESCRIPTION
https://osraav.atlassian.net/browse/OSRA-397

As per client request, limit the number of total requested sponsorships
to sponsors who are Active or On Hold. No need to limit the scope of
active sponsorship count as sponsors with active sponsorships cannot be
inactivated, and Inactive sponsors cannot start sponsorships.