### PR TITLE
Osra418 sort by table header for orphans

### DIFF
--- a/app/assets/stylesheets/hq.scss
+++ b/app/assets/stylesheets/hq.scss
@@ -39,3 +39,11 @@ ul.nav-stacked li a {
   margin: 40px auto;
   padding-left: 80px;
 }
+
+th .sort-column-asc {
+  background-color: palegreen;
+}
+
+th .sort-column-desc {
+  background-color: peachpuff;
+}

--- a/app/controllers/hq/orphans_controller.rb
+++ b/app/controllers/hq/orphans_controller.rb
@@ -6,15 +6,7 @@ class Hq::OrphansController < HqController
   ADDRESS_DETAILS = [:id, :city, :province_id, :street, :neighborhood, :details]
 
   def index
-    if params[:sort_by] == 'original_address_province_name'
-      @orphans = Orphan.includes(:original_address).order("provinces.name " + sort_direction).paginate(:page => params[:page])
-    elsif params[:sort_by] == 'orphan_list_partner_name'
-      @orphans = Orphan.includes(:orphan_list).includes(:partner).order("partners.name " + sort_direction).paginate(:page => params[:page])
-    elsif sort_column
-      @orphans = Orphan.order(sort_column + ' ' + sort_direction).paginate(:page => params[:page])
-    else
-      @orphans = Orphan.paginate(:page => params[:page])
-    end
+    @orphans = Orphan.orphan_sort(sort_column, sort_direction).paginate(:page => params[:page])
   end
 
   def show
@@ -78,7 +70,7 @@ private
 
   def sort_column
     # This method is just to verify the sort_by column passed in params, to prevent SQL injection attacks
-    Orphan.column_names.include?(params[:sort_by]) ? params[:sort_by] : nil
+    (Orphan.column_names + ['original_address_province_name','orphan_list_partner_name']).include?(params[:sort_by]) ? params[:sort_by] : nil
   end
 
   def sort_direction

--- a/app/controllers/hq/orphans_controller.rb
+++ b/app/controllers/hq/orphans_controller.rb
@@ -1,9 +1,16 @@
 class Hq::OrphansController < HqController
 
+# the solution for handling sorting basically follows the Railscast http://railscasts.com/episodes/228-sortable-table-columns
+  helper_method :sort_column, :sort_direction
+
   ADDRESS_DETAILS = [:id, :city, :province_id, :street, :neighborhood, :details]
 
   def index
-    @orphans = Orphan.paginate(:page => params[:page])
+    if sort_column
+      @orphans = Orphan.order(sort_column + ' ' + sort_direction).paginate(:page => params[:page])
+    else
+      @orphans = Orphan.paginate(:page => params[:page])
+    end
   end
 
   def show
@@ -63,5 +70,35 @@ private
               :father_deceased, original_address_attributes: ADDRESS_DETAILS,
               current_address_attributes: ADDRESS_DETAILS
             )
+  end
+
+  def sort_column
+    Orphan.column_names.include?(params[:sort_by]) ? params[:sort_by] : nil
+  end
+=begin
+  def sort_column(param_column = params[:sort_by], table = Orphan, table_column = param_column)
+    return nil if param_column.nil?
+    p "in sort_column with " + param_column + ", " + table.to_s + ', ' + table_column
+    if table_column.split('.').count == 1
+      p "just checking this table's columns"
+      table.column_names.include?(table_column) ? param_column : nil
+    else
+      p "checking association " + table_column
+      table_column = table_column.sub(/^orphan./,'')
+      return nil if table_column.split('.').count == 1
+      table_name = table_column.slice(/[^.]*/)
+      p "checking table " + table_name + " is an association"
+      if table.reflections.keys.include?(table_name)
+        p "got a match for this association - now calling sort_column recursively"
+        sort_column(param_column, table.reflections[table_name].class_name.constantize, table_column.slice(table_name.length+1, table_column.length - table_name.length))
+      else
+        return nil
+      end
+    end
+  end
+=end
+
+  def sort_direction
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
   end
 end

--- a/app/controllers/hq/orphans_controller.rb
+++ b/app/controllers/hq/orphans_controller.rb
@@ -6,7 +6,11 @@ class Hq::OrphansController < HqController
   ADDRESS_DETAILS = [:id, :city, :province_id, :street, :neighborhood, :details]
 
   def index
-    if sort_column
+    if params[:sort_by] == 'original_address_province_name'
+      @orphans = Orphan.includes(:original_address).order("provinces.name " + sort_direction).paginate(:page => params[:page])
+    elsif params[:sort_by] == 'orphan_list_partner_name'
+      @orphans = Orphan.includes(:orphan_list).includes(:partner).order("partners.name " + sort_direction).paginate(:page => params[:page])
+    elsif sort_column
       @orphans = Orphan.order(sort_column + ' ' + sort_direction).paginate(:page => params[:page])
     else
       @orphans = Orphan.paginate(:page => params[:page])
@@ -73,32 +77,12 @@ private
   end
 
   def sort_column
+    # This method is just to verify the sort_by column passed in params, to prevent SQL injection attacks
     Orphan.column_names.include?(params[:sort_by]) ? params[:sort_by] : nil
   end
-=begin
-  def sort_column(param_column = params[:sort_by], table = Orphan, table_column = param_column)
-    return nil if param_column.nil?
-    p "in sort_column with " + param_column + ", " + table.to_s + ', ' + table_column
-    if table_column.split('.').count == 1
-      p "just checking this table's columns"
-      table.column_names.include?(table_column) ? param_column : nil
-    else
-      p "checking association " + table_column
-      table_column = table_column.sub(/^orphan./,'')
-      return nil if table_column.split('.').count == 1
-      table_name = table_column.slice(/[^.]*/)
-      p "checking table " + table_name + " is an association"
-      if table.reflections.keys.include?(table_name)
-        p "got a match for this association - now calling sort_column recursively"
-        sort_column(param_column, table.reflections[table_name].class_name.constantize, table_column.slice(table_name.length+1, table_column.length - table_name.length))
-      else
-        return nil
-      end
-    end
-  end
-=end
 
   def sort_direction
+    # This method is just to verify the sort direction passed in params, to prevent SQL injection attacks
     %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,13 +11,14 @@ module ApplicationHelper
   end
 
 # sortable_column is a method used in views where the column header can be clicked to sort the records by that column
-# This solution follows the railscast http://railscasts.com/episodes/228-sortable-table-columns
+# This solution follows the railscast http://railscasts.com/episodes/228-sortable-table-columns and part of
+# http://railscasts.com/episodes/240-search-sort-paginate-with-ajax
   def sortable_column(column, title = nil)
     title ||= column.titleize
     # if the same column is clicked twice, change the sort order from asc to desc or vice versa
     direction = column == params[:sort_by] && sort_direction == 'asc' ? 'desc' : 'asc'
     css_class = column == params[:sort_by] ? "sort-column-#{sort_direction}" : nil
-    link_to title, { sort_by: column, direction: direction }, { class: css_class }
+    link_to title, params.merge(sort_by: column, direction: direction, page: nil), { class: css_class }
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,15 @@ module ApplicationHelper
   def format_month_year_date(date)
     (date || NullDate.new).strftime(MONTH_YEAR_DATE_FORMAT_STRING)
   end
+
+# sortable_column is a method used in views where the column header can be clicked to sort the records by that column
+# This solution follows the railscast http://railscasts.com/episodes/228-sortable-table-columns
+  def sortable_column(column, title = nil)
+    title ||= column.titleize
+    # if the same column is clicked twice, change the sort order from asc to desc or vice versa
+    direction = column == params[:sort_by] && sort_direction == 'asc' ? 'desc' : 'asc'
+    css_class = column == params[:sort_by] ? "sort-column-#{sort_direction}" : nil
+    link_to title, { sort_by: column, direction: direction }, { class: css_class }
+  end
+
 end

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -1,5 +1,18 @@
 class Orphan < ActiveRecord::Base
 
+  self.per_page = 3
+
+  scope :orphan_sort, ->(sort_column, sort_direction) do  
+    return nil if sort_column.nil?
+    if sort_column == 'original_address_province_name'
+      includes(:original_address).order("provinces.name " + sort_direction)
+    elsif sort_column == 'orphan_list_partner_name'
+      includes(:orphan_list).includes(:partner).order("partners.name " + sort_direction)
+    else
+      order(sort_column + ' ' + sort_direction)
+    end
+  end
+
   enum status: [
     :active,
     :inactive,

--- a/app/views/hq/orphans/index.html.erb
+++ b/app/views/hq/orphans/index.html.erb
@@ -8,43 +8,43 @@
       <thead>
         <tr>
           <th>
-            Osra Num
+            <%= sortable_column 'osra_num' %>
           </th>
           <th>
-            Name
+            <%= sortable_column 'name' %>
           </th>
           <th>
-            Father Name
+            <%= sortable_column 'father_given_name', "Father Name" %>
           </th>
           <th>
-            Date of Birth
+            <%= sortable_column 'date_of_birth' %>
           </th>
           <th>
-            Gender
+            <%= sortable_column 'gender' %>
           </th>
           <th>
-            Original Province
+            Province name
           </th>
           <th>
             Partner
           </th>
           <th>
-            Father is Martyr
+            <%= sortable_column 'father_is_martyr' %>
           </th>
           <th>
-            Father Deceased
+            <%= sortable_column 'father_deceased' %>
           </th>
           <th>
-            Mother Alive
+            <%= sortable_column 'mother_alive' %>
           </th>
           <th>
-            Priority
+            <%= sortable_column 'priority' %>
           </th>
           <th>
-            Orphan Status
+            <%= sortable_column 'status', 'Orphan Status' %>
           </th>
           <th>
-            Sponsorship
+            <%= sortable_column 'sponsorship_status', 'Sponsorship' %> 
           </th>
         </tr>
       </thead>

--- a/app/views/hq/orphans/index.html.erb
+++ b/app/views/hq/orphans/index.html.erb
@@ -14,7 +14,7 @@
             <%= sortable_column 'name' %>
           </th>
           <th>
-            <%= sortable_column 'father_given_name', "Father Name" %>
+            <%= sortable_column 'father_given_name', 'Father Name' %>
           </th>
           <th>
             <%= sortable_column 'date_of_birth' %>
@@ -23,10 +23,10 @@
             <%= sortable_column 'gender' %>
           </th>
           <th>
-            Province name
+            <%= sortable_column 'original_address_province_name', 'Province name' %>
           </th>
           <th>
-            Partner
+            <%= sortable_column 'orphan_list_partner_name', 'Partner' %>
           </th>
           <th>
             <%= sortable_column 'father_is_martyr' %>

--- a/spec/controllers/hq/orphans_controller_spec.rb
+++ b/spec/controllers/hq/orphans_controller_spec.rb
@@ -12,13 +12,35 @@ RSpec.describe Hq::OrphansController, type: :controller do
     sign_in instance_double(AdminUser)
   end
 
-  specify '#index' do
+  specify '#index with pagination' do
     expect(Orphan).to receive(:paginate).with(page: "2")
-      .and_return(orphans.paginate(per_page: 2, page: 1))
+      .and_return(orphans.paginate(per_page: 3, page: 1))
     get :index, page: "2"
 
     expect(assigns(:orphans)).to eq orphans
     expect(response).to render_template 'index'
+  end
+
+  context '#index with sorting' do
+
+
+    let(:orphans_for_sorting) { FactoryGirl.create_list(:orphan, 3) }
+    let(:orphans_sorted_by_name_asc) { orphans_for_sorting.sort{|o1, o2| o1.name <=> o2.name} }
+
+    specify 'ascending' do
+
+      get :index, page: "1", sort_by: "name", direction: "asc"
+
+      expect(assigns(:orphans)).to eq orphans_sorted_by_name_asc
+    end
+
+    specify 'descending' do
+
+      get :index, page: "1", sort_by: "date_of_birth", direction: "desc"
+
+      expect(assigns(:orphans)).to eq orphans_for_sorting.sort{|o1, o2| o1.date_of_birth <=> o2.date_of_birth}.reverse
+    end
+
   end
 
   specify '#show' do

--- a/spec/controllers/hq/orphans_controller_spec.rb
+++ b/spec/controllers/hq/orphans_controller_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Hq::OrphansController, type: :controller do
   end
 
   specify '#index with pagination' do
+    allow(Orphan).to receive(:orphan_sort).and_return(Orphan)
     expect(Orphan).to receive(:paginate).with(page: "2")
-      .and_return(orphans.paginate(per_page: 3, page: 1))
+      .and_return(orphans.paginate(per_page: 2, page: 1))
     get :index, page: "2"
 
     expect(assigns(:orphans)).to eq orphans

--- a/spec/controllers/hq/orphans_controller_spec.rb
+++ b/spec/controllers/hq/orphans_controller_spec.rb
@@ -25,13 +25,12 @@ RSpec.describe Hq::OrphansController, type: :controller do
 
 
     let(:orphans_for_sorting) { FactoryGirl.create_list(:orphan, 3) }
-    let(:orphans_sorted_by_name_asc) { orphans_for_sorting.sort{|o1, o2| o1.name <=> o2.name} }
 
     specify 'ascending' do
 
       get :index, page: "1", sort_by: "name", direction: "asc"
 
-      expect(assigns(:orphans)).to eq orphans_sorted_by_name_asc
+      expect(assigns(:orphans)).to eq orphans_for_sorting.sort{|o1, o2| o1.name <=> o2.name}
     end
 
     specify 'descending' do

--- a/spec/factories/orphans.rb
+++ b/spec/factories/orphans.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :orphan do
     name { Faker::Name.first_name }
-    date_of_birth { 10.years.ago }
+    date_of_birth { Faker::Time.between(5.years.ago, 12.years.ago) }
     gender { %w(Male Female).sample }
     contact_number { Faker::PhoneNumber.phone_number }
     father_given_name { Faker::Name.first_name }


### PR DESCRIPTION
This functionality for sorting by headers follows the design proposed in http://railscasts.com/episodes/228-sortable-table-columns and the first part of http://railscasts.com/episodes/240-search-sort-paginate-with-ajax.
There will be commonality between this sorting for Orphans and sorting other tables, so please comment particularly on these aspects so that we can agree on their design. They are:
1. The use of the helper function sortable_column
2. The use of the private methods #sort_column and #sort_direction in the controllers (to prevent SQL injection attacks)
3. The CSS class we use to indicate the current sorting column and direction (asc/desc) 
(eg we might instead want to have 2 classes one for the column and one for the direction, as shown in the railscast).
(I've just created temporarily a little CSS in /assets/stylesheets/hq.scss to make the background of the column header green if it's an ascending sort, pink if descending).