### PR TITLE
Fix randomly failing test in orphans form spec

### DIFF
--- a/spec/factories/orphans.rb
+++ b/spec/factories/orphans.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
       father_cause_of_death { Faker::Lorem.word if father_deceased }
       guardian_name { Faker::Name.first_name }
       guardian_relationship { Faker::Lorem.word }
-      guardian_id_num { Faker::Number.number(5) }
+      guardian_id_num { Faker::Number.number(5).to_i }
       alt_contact_number { Faker::PhoneNumber.phone_number }
       comments { Faker::Lorem.paragraph }
       province_code { Province.all.sample.code }

--- a/spec/views/hq/orphans/_form_spec.rb
+++ b/spec/views/hq/orphans/_form_spec.rb
@@ -44,12 +44,7 @@ RSpec.describe "hq/orphans/_form.html.erb", type: :view do
      "guardian_name", "guardian_relationship",
      "guardian_id_num", "contact_number", "alt_contact_number"].each do |field|
       if orphan_full[field]
-        if !expect(rendered).to have_selector("input[id='orphan_#{field}'][value=\"#{orphan_full[field].to_s}\"]")
-          show_me_redered
-          binding.pry
-          puts
-          raise
-        end
+        expect(rendered).to have_selector("input[id=\"orphan_#{field}\"][value=\"#{orphan_full[field]}\"]")
       else
         expect(rendered).to have_selector("input[id='orphan_#{field}']")
         expect(rendered).to_not have_selector("input[id='orphan_#{field}'][value]")


### PR DESCRIPTION
- cast the 5 digit faker guardian_id_num to an integer to prevent
  leading zeros cause intermittent failures for values set on input fields.
- this fixes a previous fail when running :-
    `rspec --order random:28201`