### PR TITLE
Osra 447 export csv with filters

### DIFF
--- a/app/controllers/hq/orphans_controller.rb
+++ b/app/controllers/hq/orphans_controller.rb
@@ -9,17 +9,17 @@ class Hq::OrphansController < HqController
     @current_sort_direction = valid_sort_direction
 
     @filters = filters_params
-    @orphans = Orphan
+    @orphans_before_paginate = Orphan
       .filter(@filters)
       .includes(valid_sort_columns_included_resource)
       .order(@current_sort_column.to_s + " " +  @current_sort_direction.to_s)
-      .paginate(:page => params[:page])
+    @orphans = @orphans_before_paginate.paginate(:page => params[:page])
 
     load_scope
 
     respond_to do |format|
       format.html
-      format.csv { send_data Orphan.to_csv(Orphan.all), filename: "orphans-#{Date.today}.csv" }
+      format.csv { send_data Orphan.to_csv(@orphans_before_paginate), filename: "orphans-#{Date.today}.csv" }
     end
   end
 

--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -9,14 +9,14 @@ class Hq::SponsorsController < HqController
     @sort_by = sort_by_params
     @sortable_by_column = true
 
-    @sponsors = Sponsor
+    @sponsors_before_paginate = Sponsor
       .filter(@filters)
       .order(@current_sort_column.to_s + " " +  @current_sort_direction.to_s)
-      .paginate(:page => params[:page])
+    @sponsors = @sponsors_before_paginate.paginate(:page => params[:page])
 
     respond_to do |format|
       format.html
-      format.csv { send_data Sponsor.to_csv(Sponsor.all), filename: "sponsors-#{Date.today}.csv" }
+      format.csv { send_data Sponsor.to_csv(@sponsors_before_paginate), filename: "sponsors-#{Date.today}.csv" }
     end
   end
 

--- a/app/views/hq/orphans/index.html.erb
+++ b/app/views/hq/orphans/index.html.erb
@@ -39,7 +39,7 @@
                   hq_orphans_path(scope: :eligible_for_sponsorship),
                   class: 'btn btn-default', role: 'button' %>
   <%- end %>
-  <%= link_to 'Export to csv', hq_orphans_path(format: :csv), class: 'btn btn-default', role: 'button' %>
+  <%= link_to 'Export to csv', hq_orphans_path(format: :csv, filters: @filters, sort_column: @current_sort_column, sort_direction: @current_sort_direction), class: 'btn btn-default', role: 'button' %>
 </div>
 
 <div class="row">

--- a/app/views/hq/sponsors/index.html.haml
+++ b/app/views/hq/sponsors/index.html.haml
@@ -2,7 +2,7 @@
 
 %div.main-content-header
   = link_to('New Sponsor', new_hq_sponsor_path, class: 'btn btn-default', role: 'button')
-  = link_to('Export to csv', hq_sponsors_path(format: :csv), class: 'btn btn-default', role: 'button')
+  = link_to('Export to csv', hq_sponsors_path(format: :csv, filters: @filters,sort_direction: @current_sort_direction  ,sort_column: @current_sort_column ,sort_by: @sort_by ), class: 'btn btn-default', role: 'button')
   %p
     Currently sponsoring #{pluralize(total_active_sponsorships, 'orphan')}
     out of #{total_requested_sponsorships} requested.

--- a/spec/controllers/hq/orphans_controller_spec.rb
+++ b/spec/controllers/hq/orphans_controller_spec.rb
@@ -40,6 +40,22 @@ RSpec.describe Hq::OrphansController, type: :controller do
       expect(response).to render_template 'index'
     end
 
+    specify "Filter-CSV" do
+      filter = build :orphan_filter
+      expect(Orphan).to receive(:filter).and_return(orphan_double)
+      allow(orphan_double).to receive_message_chain(:includes,:order,:paginate).and_return(orphans)
+      expect(Orphan).to receive(:to_csv).and_return(orphan_double)
+      expect(@controller).to receive(:send_data) {
+        @controller.render nothing: true
+      }
+
+      get :index, format: :csv, filters: filter
+
+      filter.each_key do |k|
+        expect(assigns(:filters)[k].to_s).to eq filter[k].to_s
+      end
+    end
+
     specify "Clear Filters" do
       get :index, {page: 1, commit: "Clear Filters"}
 

--- a/spec/controllers/hq/sponsors_controller_spec.rb
+++ b/spec/controllers/hq/sponsors_controller_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe Hq::SponsorsController, type: :controller do
       expect(response).to render_template 'index'
     end
 
+    specify "Filter-CSV" do
+      filter = build :sponsor_filter
+      expect(Sponsor).to receive(:filter).and_return(sponsor_double)
+      allow(sponsor_double).to receive_message_chain(:order,:paginate).and_return(sponsors)
+      expect(Sponsor).to receive(:to_csv).and_return(sponsor_double)
+      expect(@controller).to receive(:send_data) {
+        @controller.render nothing: true
+      }
+
+      get :index, format: :csv, filters: filter
+
+      filter.each_key do |k|
+        expect(assigns(:filters)[k].to_s).to eq filter[k].to_s
+      end
+    end
+
+
     specify 'column_sort' do
       allow(Sponsor).to receive(:filter).and_return(sponsor_double)
       expect(sponsor_double).to receive(:order).with("name desc").and_return(sponsor_double)

--- a/spec/views/hq/orphans/index_spec.rb
+++ b/spec/views/hq/orphans/index_spec.rb
@@ -76,12 +76,20 @@ RSpec.describe "hq/orphans/index.html.erb", type: :view do
       render
     end
 
-    it "should show link for export orphans list as csv" do
+    it "should show link for export orphans list as csv with default values" do
       assign(:filters, {})
-      assign(:sort_by, {})
-      assign(:sort_direction, {})
+      assign(:current_sort_column, "orphans.name")
+      assign(:current_sort_direction, "asc")
       render and expect(rendered).to have_link('Export to csv',
-                                    href: hq_orphans_path(format: :csv, filters: {}, sort_column: {}, sort_direction: {}))
+                                    href: hq_orphans_path(format: :csv, sort_column: "orphans.name", sort_direction: "asc"))
+    end
+
+    it "should add filters and params to the export to csv link" do
+      assign(:filters, {"created_at_from"=>"", "created_at_until"=>"", "date_of_birth_from"=>"", "date_of_birth_until"=>"", "family_name_option"=>"contains", "family_name_value"=>"", "father_given_name_option"=>"contains", "father_given_name_value"=>"", "father_is_martyr"=>"", "gender"=>"Female", "goes_to_school"=>"", "health_status"=>"", "mother_alive"=>"true", "name_option"=>"contains", "name_value"=>"", "original_address_city"=>"", "orphan_list_partner_name"=>"", "priority"=>"", "province_code"=>"", "sponsorship_status"=>"", "status"=>"", "updated_at_from"=>"", "updated_at_until"=>""})
+      assign(:current_sort_column, "orphans.name")
+      assign(:current_sort_direction, "desc")
+      render and expect(rendered).to have_link('Export to csv',
+                                    href: hq_orphans_path(format: :csv, filters: {"created_at_from"=>"", "created_at_until"=>"", "date_of_birth_from"=>"", "date_of_birth_until"=>"", "family_name_option"=>"contains", "family_name_value"=>"", "father_given_name_option"=>"contains", "father_given_name_value"=>"", "father_is_martyr"=>"", "gender"=>"Female", "goes_to_school"=>"", "health_status"=>"", "mother_alive"=>"true", "name_option"=>"contains", "name_value"=>"", "original_address_city"=>"", "orphan_list_partner_name"=>"", "priority"=>"", "province_code"=>"", "sponsorship_status"=>"", "status"=>"", "updated_at_from"=>"", "updated_at_until"=>""}, sort_column: "orphans.name", sort_direction: "desc"))
     end
   end
 

--- a/spec/views/hq/orphans/index_spec.rb
+++ b/spec/views/hq/orphans/index_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe "hq/orphans/index.html.erb", type: :view do
 
       render
     end
+
+    it "should show link for export orphans list as csv" do
+      assign(:filters, {})
+      assign(:sort_by, {})
+      assign(:sort_direction, {})
+      render and expect(rendered).to have_link('Export to csv',
+                                    href: hq_orphans_path(format: :csv, filters: {}, sort_column: {}, sort_direction: {}))
+    end
   end
 
   context 'no orphans exist' do

--- a/spec/views/hq/sponsors/index_spec.rb
+++ b/spec/views/hq/sponsors/index_spec.rb
@@ -32,8 +32,19 @@ RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
     end
   end
 
-  it "should have link for export sponsors list as csv" do
+  it "should have link for export sponsors list as csv with default values" do
+    assign(:filters, {})
+    assign(:current_sort_column, "name")
+    assign(:current_sort_direction, "asc")
     render and expect(rendered).to have_link('Export to csv',
-                                             href: hq_sponsors_path(format: :csv, filters: {}, sort_column: {}, sort_direction: {}))
+                                             href: hq_sponsors_path(format: :csv, filters: {}, sort_column: "name", sort_direction: "asc"))
+  end
+
+  it "should add filters and params to the export to csv link" do
+    assign(:filters,{"active_sponsorship_count_option"=>"equals", "active_sponsorship_count_value"=>"", "agent_id"=>"", "branch_id"=>"5", "city"=>"Wehnerburgh", "country"=>"", "created_at_from"=>"", "created_at_until"=>"", "gender"=>"Male", "name_option"=>"contains", "name_value"=>"", "organization_id"=>"", "request_fulfilled"=>"", "sponsor_type_id"=>"", "start_date_from"=>"", "start_date_until"=>"", "status_id"=>"", "updated_at_from"=>"", "updated_at_until"=>""})
+    assign(:current_sort_column, "name")
+    assign(:current_sort_direction, "desc")
+    render and expect(rendered).to have_link('Export to csv',
+                                             href: hq_sponsors_path(format: :csv, filters: {"active_sponsorship_count_option"=>"equals", "active_sponsorship_count_value"=>"", "agent_id"=>"", "branch_id"=>"5", "city"=>"Wehnerburgh", "country"=>"", "created_at_from"=>"", "created_at_until"=>"", "gender"=>"Male", "name_option"=>"contains", "name_value"=>"", "organization_id"=>"", "request_fulfilled"=>"", "sponsor_type_id"=>"", "start_date_from"=>"", "start_date_until"=>"", "status_id"=>"", "updated_at_from"=>"", "updated_at_until"=>""}, sort_column: "name", sort_direction: "desc"))
   end
 end

--- a/spec/views/hq/sponsors/index_spec.rb
+++ b/spec/views/hq/sponsors/index_spec.rb
@@ -31,4 +31,9 @@ RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
       expect(rendered).to have_link('New Sponsor', new_hq_sponsor_path)
     end
   end
+
+  it "should have link for export sponsors list as csv" do
+    render and expect(rendered).to have_link('Export to csv',
+                                             href: hq_sponsors_path(format: :csv, filters: {}, sort_column: {}, sort_direction: {}))
+  end
 end


### PR DESCRIPTION
Related to https://osraav.atlassian.net/browse/OSRA-447

- Add filters, sort direction and sort column if exists to the 'export to csv' link in the view and in the controller for orphans and sponsors.