### PR TITLE
Osra 448 display total number of records in list pages

### DIFF
--- a/app/controllers/hq/sponsors_controller.rb
+++ b/app/controllers/hq/sponsors_controller.rb
@@ -14,6 +14,8 @@ class Hq::SponsorsController < HqController
       .order(@current_sort_column.to_s + " " +  @current_sort_direction.to_s)
       .paginate(:page => params[:page])
 
+    load_scope
+
     respond_to do |format|
       format.html
       format.csv { send_data Sponsor.to_csv(Sponsor.all), filename: "sponsors-#{Date.today}.csv" }
@@ -121,6 +123,10 @@ private
 
   def valid_sort_column
     %w[osra_num name start_date request_fulfilled country].include?(params[:sort_column]) ? params[:sort_column].to_sym : :name
+  end
+
+  def load_scope
+    @sponsors_count = Sponsor.count
   end
 
 end

--- a/app/views/hq/orphans/index.html.erb
+++ b/app/views/hq/orphans/index.html.erb
@@ -204,6 +204,9 @@
           <%- end %>
         </tbody>
       </table>
+      <div class="pagination_information">
+        Displaying <%=@orphans.count.to_s%> of <%=@orphans_count.to_s%> Orphans.
+      </div>
       <div class="pagination">
         <%= will_paginate @orphans, will_paginate_render_options %>
       </div>

--- a/app/views/hq/orphans/index.html.erb
+++ b/app/views/hq/orphans/index.html.erb
@@ -39,7 +39,7 @@
                   hq_orphans_path(scope: :eligible_for_sponsorship),
                   class: 'btn btn-default', role: 'button' %>
   <%- end %>
-  <%= link_to 'Export to csv', hq_orphans_path(format: :csv), class: 'btn btn-default', role: 'button' %>
+  <%= link_to 'Export to csv', hq_orphans_path(format: :csv, filters: @filters, sort_column: @current_sort_column, sort_direction: @current_sort_direction), class: 'btn btn-default', role: 'button' %>
     <div class="pagination_information">
         Displaying <%=@orphans.count.to_s%> of <%=@orphans_count.to_s%> Orphans.
     </div>

--- a/app/views/hq/orphans/index.html.erb
+++ b/app/views/hq/orphans/index.html.erb
@@ -40,6 +40,9 @@
                   class: 'btn btn-default', role: 'button' %>
   <%- end %>
   <%= link_to 'Export to csv', hq_orphans_path(format: :csv), class: 'btn btn-default', role: 'button' %>
+    <div class="pagination_information">
+        Displaying <%=@orphans.count.to_s%> of <%=@orphans_count.to_s%> Orphans.
+    </div>
 </div>
 
 <div class="row">
@@ -204,9 +207,6 @@
           <%- end %>
         </tbody>
       </table>
-      <div class="pagination_information">
-        Displaying <%=@orphans.count.to_s%> of <%=@orphans_count.to_s%> Orphans.
-      </div>
       <div class="pagination">
         <%= will_paginate @orphans, will_paginate_render_options %>
       </div>

--- a/app/views/hq/sponsors/index.html.haml
+++ b/app/views/hq/sponsors/index.html.haml
@@ -8,3 +8,6 @@
     out of #{total_requested_sponsorships} requested.
 
 =render partial: 'hq/sponsors/sponsors.html.haml', locals: {sponsors: @sponsors, filters: @filters, sort_by: @sort_by, sortable_by_column: @sortable_by_column}
+
+%div.pagination_information
+  Displaying #{@sponsors.count.to_s} of #{@sponsors_count.to_s} Sponsors.

--- a/app/views/hq/sponsors/index.html.haml
+++ b/app/views/hq/sponsors/index.html.haml
@@ -6,8 +6,7 @@
   %p
     Currently sponsoring #{pluralize(total_active_sponsorships, 'orphan')}
     out of #{total_requested_sponsorships} requested.
+  %p
+    Displaying #{@sponsors.count.to_s} of #{@sponsors_count.to_s} Sponsors.
 
 =render partial: 'hq/sponsors/sponsors.html.haml', locals: {sponsors: @sponsors, filters: @filters, sort_by: @sort_by, sortable_by_column: @sortable_by_column}
-
-%div.pagination_information
-  Displaying #{@sponsors.count.to_s} of #{@sponsors_count.to_s} Sponsors.

--- a/spec/views/hq/orphans/index_spec.rb
+++ b/spec/views/hq/orphans/index_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe "hq/orphans/index.html.erb", type: :view do
       expect(rendered).to match /success/
     end
 
+    it 'should show total number of orphans' do
+      assign(:orphans_count, orphans_count)
+      render
+      expect(rendered).to have_content('Displaying ' + orphans.count.to_s + ' of ' + orphans_count.to_s + ' Orphans.')
+    end
+
     context 'sponsors exists' do
       before :each do
         assign(:sponsor, sponsor)

--- a/spec/views/hq/sponsors/index_spec.rb
+++ b/spec/views/hq/sponsors/index_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'will_paginate/array'
 
 RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
   before :each do
@@ -7,6 +8,13 @@ RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
     assign(:sort_by, {})
     assign(:sortable_by_column, true)
   end
+
+  let(:sponsors_count) { build_stubbed_list(:sponsor, 5).count }
+  let(:sponsors) do
+    items = build_stubbed_list :sponsor, 5
+    items.paginate(:page => 2, :per_page => 2)
+  end
+
   it 'should delegate to partial' do
     render
 
@@ -23,6 +31,13 @@ RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
     render
 
     expect(rendered).to have_text 'Currently sponsoring 3 orphans out of 10 requested.'
+  end
+
+  it 'should show total number of sponsors' do
+    assign(:sponsors_count, sponsors_count)
+    assign(:sponsors, sponsors)
+    render
+    expect(rendered).to have_content('Displaying ' + sponsors.count.to_s + ' of ' + sponsors_count.to_s + ' Sponsors.')
   end
 
   describe 'class action-items should have link' do

--- a/spec/views/hq/sponsors/index_spec.rb
+++ b/spec/views/hq/sponsors/index_spec.rb
@@ -3,7 +3,7 @@ require 'will_paginate/array'
 
 RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
   before :each do
-    assign(:sponsors, [])
+    assign(:sponsors, Sponsor.none)
     assign(:filters, {})
     assign(:sort_by, {})
     assign(:sortable_by_column, true)
@@ -19,7 +19,7 @@ RSpec.describe 'hq/sponsors/index.html.haml', type: :view do
     render
 
     expect(view).to render_template partial: 'hq/sponsors/sponsors.html.haml',
-                                    locals: {sponsors: [], filters: {}, sort_by: {}, sortable_by_column: true}
+                                    locals: {sponsors: Sponsor.none, filters: {}, sort_by: {}, sortable_by_column: true}
   end
 
   it 'shows active & requested sponsorship totals' do


### PR DESCRIPTION
Related to : https://osraav.atlassian.net/browse/OSRA-448

- Add total number of sponsors and orphans in each index page based in the message displayed in the admin version.


![osra-448](https://cloud.githubusercontent.com/assets/2061810/17935465/b9490ba2-6a1b-11e6-891c-c082d0dc045f.png)

