### PR TITLE
Allow overriding db settings

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,10 +17,10 @@
 development:
   adapter: postgresql
   encoding: unicode
-  database: osra_development
+  database: <%= ENV['DB_NAME'] || 'osra_development' %>
   pool: 5
-  username: postgres
-  password:
+  username: <%= ENV['DB_USER'] || 'postgres' %>
+  password: <%= ENV['DB_PASSWORD'] || '' %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -46,10 +46,10 @@ development:
 test: &test
   adapter: postgresql
   encoding: unicode
-  database: osra_test
+  database: <%= ENV['DB_NAME'] || 'osra_test' %>
   pool: 5
-  username: postgres
-  password:
+  username: <%= ENV['DB_USER'] || 'postgres' %>
+  password: <%= ENV['DB_PASSWORD'] || '' %>
 
 production:
   adapter: postgresql


### PR DESCRIPTION
This allows a developer to use their own database password instead of the ones hardcoded into the project