### PR TITLE
Adult orphan display

### DIFF
--- a/app/assets/stylesheets/defaults.scss
+++ b/app/assets/stylesheets/defaults.scss
@@ -73,6 +73,10 @@ a, a:hover {
   // left/right table padding
   tr > td:first-child, tr > th:first-child { padding-left: 20px; }
   tr > td:last-child, tr > th:last-child { padding-right: 20px; }
+
+  tr.adult {
+    background-color: rgba(232, 44, 12, 0.2);
+  }
 }
 
 // flashes

--- a/app/helpers/orphan_helper.rb
+++ b/app/helpers/orphan_helper.rb
@@ -1,5 +1,5 @@
 module OrphanHelper
   def child_or_adult?(orphan)
-    orphan.age_in_years > Orphan::AGE_OF_ADULTHOOD ? "adult" : "child"
+    orphan.age_in_years >= Orphan::AGE_OF_ADULTHOOD ? "adult" : "child"
   end
 end

--- a/app/helpers/orphan_helper.rb
+++ b/app/helpers/orphan_helper.rb
@@ -1,0 +1,5 @@
+module OrphanHelper
+  def over_18?(orphan)
+    orphan.age_in_years > 18 ? "adult" : "child"
+  end
+end

--- a/app/helpers/orphan_helper.rb
+++ b/app/helpers/orphan_helper.rb
@@ -1,5 +1,5 @@
 module OrphanHelper
-  def over_18?(orphan)
-    orphan.age_in_years > 18 ? "adult" : "child"
+  def child_or_adult?(orphan)
+    orphan.age_in_years > Orphan::AGE_OF_ADULTHOOD ? "adult" : "child"
   end
 end

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -21,6 +21,7 @@ class Orphan < ActiveRecord::Base
 
   AGE_OF_ELIGIBILITY_TO_JOIN = 22
   VALID_GESTATION = 1
+  DAYS_IN_YEAR = 365
 
   SPONSORSHIP_STATUS_ORDERING = %Q{
   CASE WHEN sponsorship_status = '#{Orphan.sponsorship_statuses[:previously_sponsored]}' THEN '1'
@@ -150,6 +151,10 @@ class Orphan < ActiveRecord::Base
         csv << row
       end
     end
+  end
+
+  def age_in_years
+    (Date.today - date_of_birth).to_i / DAYS_IN_YEAR
   end
 
 private

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -155,7 +155,12 @@ class Orphan < ActiveRecord::Base
   end
 
   def age_in_years
-    (Date.today - date_of_birth).to_i / DAYS_IN_YEAR
+    today = Date.today
+    dob = date_of_birth
+    born_earlier_in_year = today.month > dob.month ||
+      (today.month == dob.month && today.day >= dob.day)
+
+    today.year - date_of_birth.year - (born_earlier_in_year ? 0 : 1)
   end
 
 private

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -22,6 +22,7 @@ class Orphan < ActiveRecord::Base
   AGE_OF_ELIGIBILITY_TO_JOIN = 22
   VALID_GESTATION = 1
   DAYS_IN_YEAR = 365
+  AGE_OF_ADULTHOOD = 18
 
   SPONSORSHIP_STATUS_ORDERING = %Q{
   CASE WHEN sponsorship_status = '#{Orphan.sponsorship_statuses[:previously_sponsored]}' THEN '1'

--- a/app/views/orphans/index.html.erb
+++ b/app/views/orphans/index.html.erb
@@ -156,7 +156,7 @@
         </thead>
         <tbody>
           <%- @orphans.each do |orphan| %>
-            <tr id="orphan_<%= orphan.id %>" class="<%= over_18? orphan %>">
+            <tr id="orphan_<%= orphan.id %>" class="<%= child_or_adult? orphan %>">
               <td>
                 <%= link_to orphan.osra_num, orphan_path(orphan) %>
               </td>

--- a/app/views/orphans/index.html.erb
+++ b/app/views/orphans/index.html.erb
@@ -156,7 +156,7 @@
         </thead>
         <tbody>
           <%- @orphans.each do |orphan| %>
-            <tr id="orphan_<%= orphan.id %>">
+            <tr id="orphan_<%= orphan.id %>" class="<%= over_18? orphan %>">
               <td>
                 <%= link_to orphan.osra_num, orphan_path(orphan) %>
               </td>

--- a/spec/helpers/orphan_helper_spec.rb
+++ b/spec/helpers/orphan_helper_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe OrphanHelper, type: :helper do
+  describe "#child_or_adult?" do
+    context "when orphan is a child" do
+      it "returns 'child'" do
+        orphan = double "orphan", age_in_years: 17
+
+        expect(child_or_adult? orphan).to eq "child"
+      end
+    end
+
+    context "when orphan is an adult" do
+      it "returns 'adult'" do
+        orphan = double "orphan", age_in_years: 18
+
+        expect(child_or_adult? orphan).to eq "adult"
+      end
+    end
+  end
+end

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -433,7 +433,7 @@ describe Orphan, type: :model do
           end
         end
 
-        describe '#to_csv' do
+        describe '.to_csv' do
           it 'generate csv content for givens orphans' do
             orphan = build_stubbed :orphan, name: "John", gender: "Male", father_given_name: "Mark", family_name: "Doe"
             orphan_attrs = orphan.as_json(methods: [:full_name, :father_name])
@@ -442,6 +442,19 @@ describe Orphan, type: :model do
             output = "Osra Num,Full Name,Father Name,Date Of Birth,Gender,Province Name,Partner Name,Father Is Martyr,Father Deceased,Mother Alive,Priority,Status,Sponsorship Status,Current Sponsor\n,John Mark Doe,Mark Doe,#{orphan.date_of_birth},Male,#{orphan.province_name},partner name,#{orphan.father_is_martyr},#{orphan.father_deceased},#{orphan.mother_alive},#{orphan.priority},#{orphan.status},#{orphan.sponsorship_status},--\n"
 
             expect(Orphan.to_csv([orphan])).to eq(output)
+          end
+        end
+
+        describe "#age_in_years" do
+          it "returns age in whole years" do
+            orphan = build_stubbed :orphan, date_of_birth: 18.years.ago
+            expect(orphan.age_in_years).to eq 18
+
+            orphan = build_stubbed :orphan, date_of_birth: 18.years.ago - 1.day
+            expect(orphan.age_in_years).to eq 18
+
+            orphan = build_stubbed :orphan, date_of_birth: 18.years.ago + 1.day
+            expect(orphan.age_in_years).to eq 17
           end
         end
       end

--- a/spec/views/orphans/index_spec.rb
+++ b/spec/views/orphans/index_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "orphans/index.html.erb", type: :view do
         sponsor_osra_num: 1,
         status: "Active",
         sponsorship_status: "Unsponsored",
+        age_in_years: 15
       }
       items.map! { |item| item.merge(extra_attrs) }
       items.map! { |item| OpenStruct.new(item) }


### PR DESCRIPTION
> As an OSRA orphan manager
So that I can quickly identify orphans who are above 18 years old
I need the rows of such orphans to be highlighted in red on the index view

~Waiting for client to confirm whether orphans are considered adults at 18 or 19 years of age.~

Client responds:
> orphan becomes adult on his/her 18th birthday

![orphans](https://cloud.githubusercontent.com/assets/5029403/20433355/d905d154-adab-11e6-819d-a6707c8db374.jpg)
