### PR TITLE
Fix paperclip s3 config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,11 +81,11 @@ Osra::Application.configure do
   # Setup Paperclip for Amazon S3 uploads
   config.paperclip_defaults = {
     storage: :s3,
-    s3_region: ENV["AWS_REGION"],
     s3_credentials: {
-      bucket: ENV["S3_BUCKET_NAME"],
-      access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]
+      access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID"),
+      bucket: ENV.fetch("S3_BUCKET_NAME"),
+      s3_region: ENV.fetch("AWS_REGION"),
+      secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY")
     }
   }
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,3 +1,5 @@
+Paperclip::Attachment.default_options[:s3_host_name] = ENV.fetch("S3_HOST_NAME")
+
 module Paperclip
   class MediaTypeSpoofDetector
     def spoofed?

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,4 +1,4 @@
-Paperclip::Attachment.default_options[:s3_host_name] = ENV.fetch("S3_HOST_NAME")
+Paperclip::Attachment.default_options[:s3_host_name] = ENV["S3_HOST_NAME"] || "s3.amazonaws.com"
 
 module Paperclip
   class MediaTypeSpoofDetector


### PR DESCRIPTION
Attempting to fix S3 config for Paperclip:

![screen shot 2017-03-19 at 12 13 02 pm](https://cloud.githubusercontent.com/assets/5029403/24079971/7c83764c-0c9d-11e7-9f96-0889e9780e84.png)

- `s3_region` must be specified under `s3_credentials` under `config.paperclip_defaults` in config/environments/<environment>.rb

- production S3 bucket is in Ireland (`eu-west-1`), while dev & staging are in `us-east-1`. Hoping that the production error is due to this and can be resolved by configuring the `s3_host_name` option for Paperclip - have set `S3_HOST_NAME` Heroku ENV to `s3.amazonaws.com` for dev & staging, `osra-prod.s3.amazonaws.com` for production (as per error response from S3 in the screenshot)