### PR TITLE
Associate Orphans & Partners directly

### DIFF
--- a/app/controllers/orphans_controller.rb
+++ b/app/controllers/orphans_controller.rb
@@ -61,6 +61,7 @@ private
       [k.humanize, k]
     end
     @provinces = Province.all
+    @partners = Partner.all
   end
 
   def save_orphan
@@ -76,21 +77,21 @@ private
   end
 
   def orphan_params
-    params.require(:orphan)
-      .permit(
-              :name, :father_is_martyr, :father_occupation,
-              :father_place_of_death, :father_cause_of_death,
-              :father_date_of_death, :mother_name, :mother_alive,
-              :date_of_birth, :gender, :health_status, :schooling_status,
-              :goes_to_school, :guardian_name, :guardian_relationship,
-              :guardian_id_num, :contact_number, :alt_contact_number,
-              :sponsored_by_another_org, :another_org_sponsorship_details,
-              :minor_siblings_count, :sponsored_minor_siblings_count, :comments,
-              :status, :priority, :sequential_id, :osra_num, :orphan_list_id,
-              :province_code, :father_given_name, :family_name,
-              :father_deceased, original_address_attributes: ADDRESS_DETAILS,
-              current_address_attributes: ADDRESS_DETAILS
-            )
+    params.require(:orphan).
+      permit(
+        :alt_contact_number, :another_org_sponsorship_details, :comments,
+        :contact_number, :date_of_birth, :family_name,
+        :father_cause_of_death, :father_date_of_death, :father_deceased,
+        :father_given_name, :father_is_martyr, :father_occupation,
+        :father_place_of_death, :gender, :goes_to_school,
+        :guardian_id_num, :guardian_name, :guardian_relationship,
+        :health_status, :minor_siblings_count, :mother_alive,
+        :mother_name, :name, :orphan_list_id, :osra_num, :partner_id,
+        :priority, :province_code, :schooling_status, :sequential_id,
+        :sponsored_by_another_org, :sponsored_minor_siblings_count,
+        :status, current_address_attributes: ADDRESS_DETAILS,
+        original_address_attributes: ADDRESS_DETAILS
+      )
   end
 
   def filters_params

--- a/app/controllers/pending_orphan_lists_controller.rb
+++ b/app/controllers/pending_orphan_lists_controller.rb
@@ -51,6 +51,7 @@ class PendingOrphanListsController < ApplicationController
                                                orphan_count: 0)
     @pending_orphan_list.pending_orphans.each do |pending_orphan|
       orphan = pending_orphan.to_orphan
+      orphan.partner = @partner
       orphan_list.orphans << orphan
     end
 

--- a/app/models/orphan.rb
+++ b/app/models/orphan.rb
@@ -96,7 +96,7 @@ class Orphan < ActiveRecord::Base
   has_one :current_sponsor, through: :current_sponsorship, class_name: "Sponsor", source: :sponsor
 
   belongs_to :orphan_list
-  has_one :partner, through: :orphan_list, autosave: false
+  belongs_to :partner
 
   delegate :province_code, to: :partner, prefix: true
   delegate :province_name, to: :original_address

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -17,7 +17,7 @@ class Partner < ActiveRecord::Base
   belongs_to :province
   belongs_to :status
   has_many :orphan_lists
-  has_many :orphans, through: :orphan_lists
+  has_many :orphans
 
   delegate :code, to: :province, prefix: true
 

--- a/app/models/pending_orphan.rb
+++ b/app/models/pending_orphan.rb
@@ -6,7 +6,7 @@ class PendingOrphan < ActiveRecord::Base
   def father_name
     "#{father_given_name} #{family_name}"
   end
-  
+
   def create_orphan
     @orphan = Orphan.new
   end
@@ -17,7 +17,7 @@ class PendingOrphan < ActiveRecord::Base
     orphan
   end
 
-  def address_prefix address
+  def address_prefix(address)
     "#{address}_"
   end
 
@@ -33,7 +33,7 @@ class PendingOrphan < ActiveRecord::Base
     end
   end
 
-  def extract_and_create_address address_type
+  def extract_and_create_address(address_type)
     prefix = address_prefix address_type
     addr_fields = fields_starting_with(self.attributes, prefix)
     addr_params = remove_prefix_from_keys(addr_fields, prefix)
@@ -41,12 +41,11 @@ class PendingOrphan < ActiveRecord::Base
     orphan.send "#{address_type}=", Address.new(addr_params)
   end
 
-  def fields_starting_with dict, prefix
-    dict.select {|key, _| String(key).starts_with? prefix}
+  def fields_starting_with(dict, prefix)
+    dict.select { |key, _| String(key).starts_with? prefix }
   end
 
   def remove_prefix_from_keys(dict, prefix)
     dict.map{ |key, val| [(String(key).gsub prefix, ''), val] }.to_h
   end
-
 end

--- a/app/views/orphans/_form.html.erb
+++ b/app/views/orphans/_form.html.erb
@@ -3,10 +3,10 @@
   <%= render 'shared/errors', object: f.object %>
   <fieldset>
     <div class="form-group">
-      <%= f.submit class: 'btn btn-primary' %>
+      <%= f.submit class: 'btn btn-primary', id: 'first-submit' %>
       <%= link_to('Cancel',
                   orphan_path(f.object.id),
-                  class: 'btn btn-default btn-cancel', role: 'button') %>
+                  class: 'btn btn-default btn-cancel', id: 'first-cancel', role: 'button') %>
     </div>
 
     <div class="panel panel-default">

--- a/app/views/orphans/_form.html.erb
+++ b/app/views/orphans/_form.html.erb
@@ -2,6 +2,28 @@
              html: {class: "records_form", role: "form"} do |f| %>
   <%= render 'shared/errors', object: f.object %>
   <fieldset>
+    <div class="form-group">
+      <%= f.submit class: 'btn btn-primary' %>
+      <%= link_to('Cancel',
+                  orphan_path(f.object.id),
+                  class: 'btn btn-default btn-cancel', role: 'button') %>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          Field partner
+        </h3>
+        <div class="panel-body">
+          <div class="form-group">
+            <%= f.label_for_field :partner %>
+            <%= f.collection_select :partner_id,
+            partners, :id, :name, {},  {class: "form-control"} %>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title">Orphan Details</h3>

--- a/app/views/orphans/edit.html.erb
+++ b/app/views/orphans/edit.html.erb
@@ -3,4 +3,5 @@
 <%= render partial: 'form', locals: { orphan: @orphan,
                                       statuses: @statuses,
                                       sponsorship_statuses: @sponsorship_statuses,
-                                      provinces: @provinces }%>
+                                      provinces: @provinces,
+                                      partners: @partners }%>

--- a/db/migrate/20170712082259_associate_partners_and_orphans_directly.rb
+++ b/db/migrate/20170712082259_associate_partners_and_orphans_directly.rb
@@ -1,0 +1,15 @@
+class AssociatePartnersAndOrphansDirectly < ActiveRecord::Migration
+  def up
+    add_reference :orphans, :partner, index: true, foreign_key: true
+
+    Orphan.reset_column_information
+    orphans = Orphan.all
+    orphans.each do |orphan|
+      orphan.update(partner_id: orphan.orphan_list.partner.id)
+    end
+  end
+
+  def down
+    remove_reference :orphans, :partner, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161105112734) do
+ActiveRecord::Schema.define(version: 20170712082259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,10 +122,12 @@ ActiveRecord::Schema.define(version: 20161105112734) do
     t.integer  "status",                                      default: 0
     t.integer  "sponsorship_status",                          default: 0
     t.boolean  "father_deceased",                             default: false
+    t.integer  "partner_id"
   end
 
   add_index "orphans", ["orphan_list_id"], name: "index_orphans_on_orphan_list_id", using: :btree
   add_index "orphans", ["osra_num"], name: "index_orphans_on_osra_num", unique: true, using: :btree
+  add_index "orphans", ["partner_id"], name: "index_orphans_on_partner_id", using: :btree
   add_index "orphans", ["priority"], name: "index_orphans_on_priority", using: :btree
   add_index "orphans", ["sequential_id"], name: "index_orphans_on_sequential_id", using: :btree
 
@@ -284,4 +286,5 @@ ActiveRecord::Schema.define(version: 20161105112734) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["user_name"], name: "index_users_on_user_name", unique: true, using: :btree
 
+  add_foreign_key "orphans", "partners"
 end

--- a/lib/orphan_importer.rb
+++ b/lib/orphan_importer.rb
@@ -68,6 +68,7 @@ class OrphanImporter
   def check_orphan_validity(fields, row)
     orphan = PendingOrphan.new(fields).to_orphan
     orphan.partner = @partner
+    orphan.orphan_list = OrphanList.new
     unless orphan.valid?
       add_import_errors "invalid orphan attributes for row #{row}",
         orphan.errors.full_messages.join('; ')

--- a/spec/controllers/pending_orphan_lists_controller_spec.rb
+++ b/spec/controllers/pending_orphan_lists_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe PendingOrphanListsController, type: :controller do
   end
 
   describe 'import' do
-    let(:orphan) { instance_double Orphan, :save! => true }
+    let(:orphan) { instance_double Orphan, :save! => true, :partner= => true }
     let(:pending_orphan) { instance_double PendingOrphan, :save! => true }
     let(:orphans_to_import) { [orphan] }
 

--- a/spec/factories/orphans.rb
+++ b/spec/factories/orphans.rb
@@ -17,6 +17,7 @@ FactoryGirl.define do
     association :original_address, factory: :address
     association :current_address, factory: :address
     orphan_list
+    partner
 
     trait :random_optional_fields do
       status { Orphan.statuses.values.sample }

--- a/spec/features/orphan_spec.rb
+++ b/spec/features/orphan_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Orphan', :type => :feature do
     select_multiple_check_box ['orphan[goes_to_school]', 'orphan[father_deceased]', 'orphan[mother_alive]', 'orphan[father_is_martyr]',
     'orphan[sponsored_by_another_org]']
 
-    and_i_click_button "Update Orphan"
+    and_i_click_button 'first-submit'
     and_i_should_be_on "orphan_page", { orphan_id: 1 }
     checks_multiple_fields output
 
@@ -87,7 +87,7 @@ RSpec.feature 'Orphan', :type => :feature do
     and_i_click_link "Edit Orphan"
     and_i_should_be_on "edit_orphan_page", { orphan_id: 1 }
     fill_in 'orphan[date_of_birth]', with: '1950-01-01'
-    and_i_click_button "Update Orphan"
+    and_i_click_button "first-submit"
     and_i_should_see "Date of birth Orphan must be younger than 22 years old to join OSRA."
   end
 
@@ -96,7 +96,7 @@ RSpec.feature 'Orphan', :type => :feature do
     and_i_click_link "Edit Orphan"
     and_i_should_be_on "edit_orphan_page", { orphan_id: 1 }
     fill_in 'orphan[name]', with: 'Orphan N'
-    and_i_click_link "Cancel"
+    and_i_click_link "first-cancel"
     and_i_should_be_on "orphan_page", { orphan_id: 1 }
   end
   

--- a/spec/models/orphan_spec.rb
+++ b/spec/models/orphan_spec.rb
@@ -65,7 +65,7 @@ describe Orphan, type: :model do
   it { is_expected.to have_many :sponsorships }
   it { is_expected.to have_many(:sponsors).through :sponsorships }
 
-  it { is_expected.to have_one(:partner).through(:orphan_list).autosave(false) }
+  it { is_expected.to belong_to(:partner) }
 
   describe "validates father's death details:" do
     let(:orphan) { build :orphan }

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -25,7 +25,7 @@ describe Partner, type: :model do
   end
 
   it { is_expected.to have_many :orphan_lists }
-  it { is_expected.to have_many(:orphans).through :orphan_lists }
+  it { is_expected.to have_many(:orphans) }
 
   it 'should override the default pagination per_page' do
     expect(Partner.per_page).to eq 10

--- a/spec/views/orphans/_form_spec.rb
+++ b/spec/views/orphans/_form_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "orphans/_form.html.erb", type: :view do
   let(:sponsorship_statuses) do
     Orphan.sponsorship_statuses.keys.map { |k| [k.humanize, k] }
   end
+  let(:partners) { Partner.all }
   let(:provinces) { Province.all }
   let(:orphan_full) do
     build_stubbed :orphan_full
@@ -14,9 +15,10 @@ RSpec.describe "orphans/_form.html.erb", type: :view do
   def render_orphan_form current_orphan
         render partial: 'orphans/form.html.erb',
                         locals: { orphan: current_orphan,
-                                  statuses: statuses,
+                                  partners: partners,
+                                  provinces: provinces,
                                   sponsorship_statuses: sponsorship_statuses,
-                                  provinces: provinces
+                                  statuses: statuses
                                 }
   end
 

--- a/spec/views/orphans/edit_spec.rb
+++ b/spec/views/orphans/edit_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'orphans/edit.html.erb', type: :view do
   before :each do
-    assign :statuses, []
-    assign :sponsorship_statuses, []
-    assign :provinces, []
     assign :orphan, build_stubbed(:orphan_full)
+    assign :partners, []
+    assign :provinces, []
+    assign :sponsorship_statuses, []
+    assign :statuses, []
   end
 
   it 'renders the form partial' do


### PR DESCRIPTION
- done in order to allow client to reassign orphans to partners other
than the one who originally uploaded the orphan list
- migration to add `:partner_id` to orphans table and populate it with
`orphan.orphan_list.partner.id`
- model changes to Orphan & Partner to replace previous `through:
orphan_list` association with direct
- OrphanImporter: associate in-memory orphans with new OrphanLists to
allow them to pass validation
- PendingOrphanListsController: explicitly assign new orphan's partner
- UI & controller changes to permit reassigning orphan to a new partner